### PR TITLE
Add type parameters to Key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slotmap"
-version = "0.2.0"  # Remember to update html_root_url!
+version = "0.3.0"  # Remember to update html_root_url!
 authors = ["Orson Peters <orsonpeters@gmail.com>"]
 description = "Slotmap data structure"
 license = "Zlib"

--- a/examples/doubly_linked_list.rs
+++ b/examples/doubly_linked_list.rs
@@ -6,14 +6,14 @@ use slotmap::{SlotMap, Key};
 
 struct Node<T> {
     value: T,
-    prev: Key,
-    next: Key,
+    prev: Key<Node<T>>,
+    next: Key<Node<T>>,
 }
 
 struct List<T> {
     sm: SlotMap<Node<T>>,
-    head: Key,
-    tail: Key,
+    head: Key<Node<T>>,
+    tail: Key<Node<T>>,
 }
 
 impl<T> List<T> {

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -211,11 +211,7 @@ impl<T> DenseSlotMap<T> {
 
         if let Some(slot) = self.slots.get_mut(idx) {
             let occupied_version = slot.version | 1;
-            let key = Key {
-                idx: idx as u32,
-                version: occupied_version,
-                value_type: std::marker::PhantomData,
-            };
+            let key = Key::new(idx as u32, occupied_version);
 
             // Push value before adjusting slots/freelist in case f panics.
             self.key_values.push(KeyValue { key, value: f(key) });
@@ -226,11 +222,7 @@ impl<T> DenseSlotMap<T> {
             return key;
         }
 
-        let key = Key {
-            idx: idx as u32,
-            version: 1,
-            value_type: std::marker::PhantomData,
-        };
+        let key = Key::new(idx as u32, 1);
 
         // Push value before adjusting slots/freelist in case f panics.
         self.key_values.push(KeyValue { key, value: f(key) });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,13 +114,22 @@ pub use dense::DenseSlotMap;
 /// `Ord` so they can be used in e.g.
 /// [`BTreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html)
 /// but their order is arbitrary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Key {
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Key<T> {
     idx: u32,
     version: u32,
+    value_type: std::marker::PhantomData<T>,
 }
 
-impl Key {
+impl <T> Copy for Key<T> {}
+
+impl <T> Clone for Key<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl <T> Key<T> {
     /// Creates a new key that is always invalid and distinct from any non-null
     /// key. A null key can only be created through this method, or default
     /// initialization of `Key`.
@@ -142,6 +151,7 @@ impl Key {
         Self {
             idx: std::u32::MAX,
             version: 1,
+            value_type: std::marker::PhantomData,
         }
     }
 
@@ -161,7 +171,7 @@ impl Key {
     }
 }
 
-impl Default for Key {
+impl <T> Default for Key<T> {
     fn default() -> Self {
         Self::null()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/slotmap/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/slotmap/0.3.0")]
 #![crate_name = "slotmap"]
 
 //! # slotmap

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ impl <T> Key<T> {
     ///
     /// ```
     /// # use slotmap::*;
-    /// let a = Key::null();
-    /// let b = Key::default();
+    /// let a: Key<i32> = Key::null();
+    /// let b: Key<i32> = Key::default();
     /// assert_eq!(a, b);
     /// ```
     pub fn is_null(self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,12 @@ pub struct Key<T> {
     value_type: std::marker::PhantomData<T>,
 }
 
+// Copy is implemented manually because we want Key<T> to implement Copy even
+// when T is not Copy.
 impl <T> Copy for Key<T> {}
 
+// Clone is implemented manually because we want Key<T> to implement Clone even
+// when T is not Clone.
 impl <T> Clone for Key<T> {
     fn clone(&self) -> Self {
         *self
@@ -168,6 +172,16 @@ impl <T> Key<T> {
     /// ```
     pub fn is_null(self) -> bool {
         self.idx == std::u32::MAX
+    }
+
+    // Creates a new key. This exists to avoid typing std::marker::PhantomData
+    // every time, but is not public because users cannot create arbitrary keys.
+    fn new(idx: u32, version: u32) -> Self {
+        Self {
+            idx,
+            version,
+            value_type: std::marker::PhantomData,
+        }
     }
 }
 

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -190,7 +190,7 @@ impl<T> SlotMap<T> {
     /// sm.remove(key);
     /// assert_eq!(sm.contains_key(key), false);
     /// ```
-    pub fn contains_key(&self, key: Key) -> bool {
+    pub fn contains_key(&self, key: Key<T>) -> bool {
         self.slots
             .get(key.idx as usize)
             .map(|slot| slot.version == key.version)
@@ -213,7 +213,7 @@ impl<T> SlotMap<T> {
     /// let key = sm.insert(42);
     /// assert_eq!(sm[key], 42);
     /// ```
-    pub fn insert(&mut self, value: T) -> Key {
+    pub fn insert(&mut self, value: T) -> Key<T> {
         self.insert_with_key(|_| value)
     }
 
@@ -234,9 +234,9 @@ impl<T> SlotMap<T> {
     /// let key = sm.insert_with_key(|k| (k, 20));
     /// assert_eq!(sm[key], (key, 20));
     /// ```
-    pub fn insert_with_key<F>(&mut self, f: F) -> Key
+    pub fn insert_with_key<F>(&mut self, f: F) -> Key<T>
     where
-        F: FnOnce(Key) -> T,
+        F: FnOnce(Key<T>) -> T,
     {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
@@ -251,6 +251,7 @@ impl<T> SlotMap<T> {
             let key = Key {
                 idx: idx as u32,
                 version: occupied_version,
+                value_type: std::marker::PhantomData,
             };
 
             // Assign slot.value first in case f panics.
@@ -264,6 +265,7 @@ impl<T> SlotMap<T> {
         let key = Key {
             idx: idx as u32,
             version: 1,
+            value_type: std::marker::PhantomData,
         };
 
         // Create new slot before adjusting freelist in case f panics.
@@ -306,7 +308,7 @@ impl<T> SlotMap<T> {
     /// assert_eq!(sm.remove(key), Some(42));
     /// assert_eq!(sm.remove(key), None);
     /// ```
-    pub fn remove(&mut self, key: Key) -> Option<T> {
+    pub fn remove(&mut self, key: Key<T>) -> Option<T> {
         if self.contains_key(key) {
             // This is safe because we know that the slot is occupied.
             Some(unsafe { self.remove_from_slot(key.idx as usize) })
@@ -344,7 +346,7 @@ impl<T> SlotMap<T> {
     /// ```
     pub fn retain<F>(&mut self, mut f: F)
     where
-        F: FnMut(Key, &mut T) -> bool,
+        F: FnMut(Key<T>, &mut T) -> bool,
     {
         let len = self.slots.len();
         for i in 0..len {
@@ -354,6 +356,7 @@ impl<T> SlotMap<T> {
                 let key = Key {
                     idx: i as u32,
                     version: slot.version,
+                    value_type: std::marker::PhantomData,
                 };
 
                 slot.occupied() && !f(key, &mut slot.value)
@@ -423,7 +426,7 @@ impl<T> SlotMap<T> {
     /// sm.remove(key);
     /// assert_eq!(sm.get(key), None);
     /// ```
-    pub fn get(&self, key: Key) -> Option<&T> {
+    pub fn get(&self, key: Key<T>) -> Option<&T> {
         self.slots
             .get(key.idx as usize)
             .filter(|slot| slot.version == key.version)
@@ -448,7 +451,7 @@ impl<T> SlotMap<T> {
     /// sm.remove(key);
     /// // sm.get_unchecked(key) is now dangerous!
     /// ```
-    pub unsafe fn get_unchecked(&self, key: Key) -> &T {
+    pub unsafe fn get_unchecked(&self, key: Key<T>) -> &T {
         &self.slots.get_unchecked(key.idx as usize).value
     }
 
@@ -465,7 +468,7 @@ impl<T> SlotMap<T> {
     /// }
     /// assert_eq!(sm[key], 6.5);
     /// ```
-    pub fn get_mut(&mut self, key: Key) -> Option<&mut T> {
+    pub fn get_mut(&mut self, key: Key<T>) -> Option<&mut T> {
         self.slots
             .get_mut(key.idx as usize)
             .filter(|slot| slot.version == key.version)
@@ -491,7 +494,7 @@ impl<T> SlotMap<T> {
     /// sm.remove(key);
     /// // sm.get_unchecked_mut(key) is now dangerous!
     /// ```
-    pub unsafe fn get_unchecked_mut(&mut self, key: Key) -> &mut T {
+    pub unsafe fn get_unchecked_mut(&mut self, key: Key<T>) -> &mut T {
         &mut self.slots.get_unchecked_mut(key.idx as usize).value
     }
 
@@ -628,10 +631,10 @@ impl<T> Default for SlotMap<T> {
     }
 }
 
-impl<T> Index<Key> for SlotMap<T> {
+impl<T> Index<Key<T>> for SlotMap<T> {
     type Output = T;
 
-    fn index(&self, key: Key) -> &T {
+    fn index(&self, key: Key<T>) -> &T {
         match self.get(key) {
             Some(r) => r,
             None => panic!("invalid SlotMap key used"),
@@ -639,8 +642,8 @@ impl<T> Index<Key> for SlotMap<T> {
     }
 }
 
-impl<T> IndexMut<Key> for SlotMap<T> {
-    fn index_mut(&mut self, key: Key) -> &mut T {
+impl<T> IndexMut<Key<T>> for SlotMap<T> {
+    fn index_mut(&mut self, key: Key<T>) -> &mut T {
         match self.get_mut(key) {
             Some(r) => r,
             None => panic!("invalid SlotMap key used"),
@@ -697,9 +700,9 @@ pub struct ValuesMut<'a, T: 'a> {
 }
 
 impl<'a, T> Iterator for Drain<'a, T> {
-    type Item = (Key, T);
+    type Item = (Key<T>, T);
 
-    fn next(&mut self) -> Option<(Key, T)> {
+    fn next(&mut self) -> Option<(Key<T>, T)> {
         let len = self.sm.slots.len();
         while self.cur < len {
             let idx = self.cur;
@@ -711,6 +714,7 @@ impl<'a, T> Iterator for Drain<'a, T> {
                     let key = Key {
                         idx: idx as u32,
                         version: self.sm.slots.get_unchecked(idx).version,
+                        value_type: std::marker::PhantomData,
                     };
 
                     self.num_left -= 1;
@@ -734,14 +738,15 @@ impl<'a, T> Drop for Drain<'a, T> {
 }
 
 impl<T> Iterator for IntoIter<T> {
-    type Item = (Key, T);
+    type Item = (Key<T>, T);
 
-    fn next(&mut self) -> Option<(Key, T)> {
+    fn next(&mut self) -> Option<(Key<T>, T)> {
         while let Some((idx, mut slot)) = self.slots.next() {
             if slot.occupied() {
                 let key = Key {
                     idx: idx as u32,
                     version: slot.version,
+                    value_type: std::marker::PhantomData,
                 };
 
                 // Prevent dropping after extracting the value.
@@ -762,14 +767,15 @@ impl<T> Iterator for IntoIter<T> {
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
-    type Item = (Key, &'a T);
+    type Item = (Key<T>, &'a T);
 
-    fn next(&mut self) -> Option<(Key, &'a T)> {
+    fn next(&mut self) -> Option<(Key<T>, &'a T)> {
         while let Some((idx, slot)) = self.slots.next() {
             if slot.occupied() {
                 let key = Key {
                     idx: idx as u32,
                     version: slot.version,
+                    value_type: std::marker::PhantomData,
                 };
 
                 self.num_left -= 1;
@@ -786,14 +792,15 @@ impl<'a, T> Iterator for Iter<'a, T> {
 }
 
 impl<'a, T> Iterator for IterMut<'a, T> {
-    type Item = (Key, &'a mut T);
+    type Item = (Key<T>, &'a mut T);
 
-    fn next(&mut self) -> Option<(Key, &'a mut T)> {
+    fn next(&mut self) -> Option<(Key<T>, &'a mut T)> {
         while let Some((idx, slot)) = self.slots.next() {
             if slot.occupied() {
                 let key = Key {
                     idx: idx as u32,
                     version: slot.version,
+                    value_type: std::marker::PhantomData,
                 };
 
                 self.num_left -= 1;
@@ -810,9 +817,9 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 }
 
 impl<'a, T> Iterator for Keys<'a, T> {
-    type Item = Key;
+    type Item = Key<T>;
 
-    fn next(&mut self) -> Option<Key> {
+    fn next(&mut self) -> Option<Key<T>> {
         self.inner.next().map(|(key, _)| key)
     }
 
@@ -846,7 +853,7 @@ impl<'a, T> Iterator for ValuesMut<'a, T> {
 }
 
 impl<'a, T> IntoIterator for &'a SlotMap<T> {
-    type Item = (Key, &'a T);
+    type Item = (Key<T>, &'a T);
     type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -855,7 +862,7 @@ impl<'a, T> IntoIterator for &'a SlotMap<T> {
 }
 
 impl<'a, T> IntoIterator for &'a mut SlotMap<T> {
-    type Item = (Key, &'a mut T);
+    type Item = (Key<T>, &'a mut T);
     type IntoIter = IterMut<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -864,7 +871,7 @@ impl<'a, T> IntoIterator for &'a mut SlotMap<T> {
 }
 
 impl<T> IntoIterator for SlotMap<T> {
-    type Item = (Key, T);
+    type Item = (Key<T>, T);
     type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {


### PR DESCRIPTION
I added a type parameter to Key (now Key<T>) with PhantomData. I'm thinking this can prevent errors in using the wrong key if someone has multiple slotmaps of different types. 

So this does not pass all the tests, and it might be impossible to add. That's because Key<T> is impossible with `insert_with_key`, since it results in a recursive Key type. Is it possible to add type parameters to Key at all then? The only thing I can think of right now is something like having a `Key<T>` and a `RecursiveKey` type.