### PR TITLE
edition=2018, no_std, try_reserve, auto impl key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ repository = "https://github.com/orlp/slotmap"
 readme = "README.md"
 keywords = ["slotmap", "storage", "allocator", "stable", "reference"]
 categories = ["data-structures", "memory-management", "caching"]
+edition = "2018"
 
 [features]
 unstable = []
+no_std = ["unstable"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -285,6 +285,31 @@ impl<K: Key, V: Slottable> HopSlotMap<K, V> {
         self.slots.reserve(needed);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements to be
+    /// inserted in the `SlotMap`. The collection may reserve more space to
+    /// avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new allocation size overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// sm.insert("foo");
+    /// sm.try_reserve(32).unwrap();
+    /// assert!(sm.capacity() >= 33);
+    /// ```
+    #[cfg(feature = "unstable")]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+        // One slot is reserved for the sentinel.
+        let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
+        self.slots.try_reserve(needed)
+    }
+
+
     /// Returns `true` if the slot map contains `key`.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,11 @@ pub trait Key: From<KeyData> + Into<KeyData> {
     }
 }
 
+impl<T> Key for T
+where
+    T: From<KeyData> + Into<KeyData>
+{ }
+
 /// A helper macro to conveniently create new key types. If you use a new key
 /// type for each slot map you create you can entirely prevent using the wrong
 /// key on the wrong slot map.
@@ -411,8 +416,6 @@ macro_rules! new_key_type {
                 k.0
             }
         }
-
-        impl $crate::Key for $name { }
 
         $crate::__serialize_key!($name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/slotmap/0.3.0")]
 #![crate_name = "slotmap"]
-#![cfg_attr(feature = "unstable", feature(untagged_unions, alloc))]
+#![cfg_attr(feature = "unstable", feature(untagged_unions, alloc, try_reserve))]
 #![cfg_attr(all(feature = "no_std", not(test)), no_std)]
 
 //! # slotmap

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -270,6 +270,30 @@ impl<K: Key, V: Slottable> SlotMap<K, V> {
         self.slots.reserve(needed);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements to be
+    /// inserted in the `SlotMap`. The collection may reserve more space to
+    /// avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new allocation size overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// sm.insert("foo");
+    /// sm.try_reserve(32).unwrap();
+    /// assert!(sm.capacity() >= 33);
+    /// ```
+    #[cfg(feature = "unstable")]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+        // One slot is reserved for the sentinel.
+        let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
+        self.slots.try_reserve(needed)
+    }
+
     /// Returns `true` if the slot map contains `key`.
     ///
     /// # Examples

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -1,14 +1,18 @@
 // Necessary for the union differing on stable/nightly.
-#![allow(unused_unsafe)]
+#![cfg_attr(not(feature = "unstable"), allow(unused_unsafe))]
 
 //! Contains the slot map implementation.
 
-use std;
-use std::iter::{Enumerate, FusedIterator};
-use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
-use std::ops::{Index, IndexMut};
-use std::{fmt, ptr};
+use core::iter::{Enumerate, FusedIterator};
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ops::{Index, IndexMut};
+use core::{fmt, ptr};
+
+#[cfg(feature = "no_std")]
+use crate::alloc::vec::Vec;
+#[cfg(feature = "unstable")]
+use crate::alloc::collections::CollectionAllocErr;
 
 use super::{DefaultKey, Key, KeyData, Slottable};
 
@@ -69,7 +73,7 @@ impl<T: Slottable> Slot<T> {
 
 impl<T: Slottable> Drop for Slot<T> {
     fn drop(&mut self) {
-        if std::mem::needs_drop::<T>() && self.occupied() {
+        if core::mem::needs_drop::<T>() && self.occupied() {
             // This is safe because we checked that we're occupied.
             unsafe {
                 ManuallyDrop::drop(&mut self.u.value);
@@ -328,7 +332,7 @@ impl<K: Key, V: Slottable> SlotMap<K, V> {
     {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
-        if new_num_elems == std::u32::MAX {
+        if new_num_elems == core::u32::MAX {
             panic!("SlotMap number of elements overflow");
         }
 
@@ -769,7 +773,7 @@ pub struct Drain<'a, K: 'a + Key, V: 'a + Slottable> {
 #[derive(Debug)]
 pub struct IntoIter<K: Key, V: Slottable> {
     num_left: usize,
-    slots: Enumerate<std::vec::IntoIter<Slot<V>>>,
+    slots: Enumerate<crate::alloc::vec::IntoIter<Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -777,7 +781,7 @@ pub struct IntoIter<K: Key, V: Slottable> {
 #[derive(Debug)]
 pub struct Iter<'a, K: 'a + Key, V: 'a + Slottable> {
     num_left: usize,
-    slots: Enumerate<std::slice::Iter<'a, Slot<V>>>,
+    slots: Enumerate<core::slice::Iter<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -785,7 +789,7 @@ pub struct Iter<'a, K: 'a + Key, V: 'a + Slottable> {
 #[derive(Debug)]
 pub struct IterMut<'a, K: 'a + Key, V: 'a + Slottable> {
     num_left: usize,
-    slots: Enumerate<std::slice::IterMut<'a, Slot<V>>>,
+    slots: Enumerate<core::slice::IterMut<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -1101,8 +1105,8 @@ mod serialize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
+    use super::*;
 
     #[cfg(feature = "serde")]
     use serde_json;
@@ -1110,9 +1114,9 @@ mod tests {
     #[cfg(feature = "unstable")]
     #[test]
     fn check_drops() {
-        let drops = std::cell::RefCell::new(0usize);
+        let drops = core::cell::RefCell::new(0usize);
         #[derive(Clone)]
-        struct CountDrop<'a>(&'a std::cell::RefCell<usize>);
+        struct CountDrop<'a>(&'a core::cell::RefCell<usize>);
         impl<'a> Drop for CountDrop<'a> {
             fn drop(&mut self) {
                 *self.0.borrow_mut() += 1;

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -179,6 +179,28 @@ impl<K: Key, V> SparseSecondaryMap<K, V> {
         self.slots.reserve(additional);
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements to be
+    /// inserted in the `SlotMap`. The collection may reserve more space to
+    /// avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new allocation size overflows `usize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// sm.insert("foo");
+    /// sm.try_reserve(32).unwrap();
+    /// assert!(sm.capacity() >= 33);
+    /// ```
+    #[cfg(feature = "unstable")]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+        self.slots.try_reserve(additional)
+    }
+
     /// Returns `true` if the secondary map contains `key`.
     ///
     /// # Examples

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -1,12 +1,16 @@
 //! Contains the sparse secondary map implementation.
 
 use super::{is_older_version, Key, KeyData};
-use std;
-use std::collections::hash_map;
-use std::collections::hash_map::HashMap;
-use std::iter::{Extend, FromIterator, FusedIterator};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+use core::iter::{Extend, FromIterator, FusedIterator};
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut};
+
+use crate::alloc::collections::hash_map;
+use crate::alloc::collections::hash_map::HashMap;
+#[cfg(feature = "no_std")]
+use crate::alloc::prelude::*;
+#[cfg(feature = "unstable")]
+use crate::alloc::collections::CollectionAllocErr;
 
 #[derive(Debug)]
 struct Slot<T> {
@@ -219,7 +223,7 @@ impl<K: Key, V> SparseSecondaryMap<K, V> {
 
         if let Some(slot) = self.slots.get_mut(&key.idx) {
             if slot.version == key.version.get() {
-                return Some(std::mem::replace(&mut slot.value, value));
+                return Some(core::mem::replace(&mut slot.value, value));
             }
 
             // Don't replace existing newer values.
@@ -344,7 +348,7 @@ impl<K: Key, V> SparseSecondaryMap<K, V> {
     ///
     /// ```
     /// # use slotmap::*;
-    /// # use std::iter::FromIterator;
+    /// # use core::iter::FromIterator;
     /// let mut sm = SlotMap::new();
     /// let k = sm.insert(0);
     /// let mut sec = SparseSecondaryMap::new();
@@ -845,8 +849,8 @@ mod serialize {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use *;
+    use crate::alloc::collections::HashMap;
+    use crate::*;
 
     #[cfg(feature = "serde")]
     use serde_json;


### PR DESCRIPTION
Hello. Just a few quick changes to support `edition=2018`, `#[no_std]`, and `try_reserve`.

The automatic implementation of Key will be a breaking change if anything external already implements it. But they don't need to implement these functions as far as I can tell, so the marker should be automatic.

There is no `reserve` in `secondary.rs`, is this intended?