### PR TITLE
Add support for try_reserve under unstable

### DIFF
--- a/src/hop.rs
+++ b/src/hop.rs
@@ -18,6 +18,8 @@ use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Index, IndexMut};
 use std::{fmt, ptr};
+#[cfg(feature = "unstable")]
+use std::collections::CollectionAllocErr;
 
 use super::{DefaultKey, Key, KeyData, Slottable};
 
@@ -282,6 +284,26 @@ impl<K: Key, V: Slottable> HopSlotMap<K, V> {
         // One slot is reserved for the freelist sentinel.
         let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
         self.slots.reserve(needed);
+    }
+
+    /// Tries to reserve capacity for at least `additional` more elements to be
+    /// inserted in the `HopSlotMap`. The collection may reserve more space to
+    /// avoid frequent reallocations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = HopSlotMap::new();
+    /// sm.insert("foo");
+    /// sm.try_reserve(32).unwrap();
+    /// assert!(sm.capacity() >= 33);
+    /// ```
+    #[cfg(feature = "unstable")]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+        // One slot is reserved for the freelist sentinel.
+        let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
+        self.slots.try_reserve(needed)
     }
 
     /// Returns `true` if the slot map contains `key`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/slotmap/0.3.0")]
 #![crate_name = "slotmap"]
-#![cfg_attr(feature = "unstable", feature(untagged_unions))]
+#![cfg_attr(feature = "unstable", feature(untagged_unions, try_reserve))]
 
 //! # slotmap
 //!

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -9,6 +9,8 @@ use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Index, IndexMut};
 use std::{fmt, ptr};
+#[cfg(feature = "unstable")]
+use std::collections::CollectionAllocErr;
 
 use super::{DefaultKey, Key, KeyData, Slottable};
 
@@ -264,6 +266,26 @@ impl<K: Key, V: Slottable> SlotMap<K, V> {
         // One slot is reserved for the sentinel.
         let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
         self.slots.reserve(needed);
+    }
+
+    /// Tries to reserve capacity for at least `additional` more elements to be
+    /// inserted in the `SlotMap`. The collection may reserve more space to
+    /// avoid frequent reallocations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// sm.insert("foo");
+    /// sm.try_reserve(32).unwrap();
+    /// assert!(sm.capacity() >= 33);
+    /// ```
+    #[cfg(feature = "unstable")]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+        // One slot is reserved for the sentinel.
+        let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
+        self.slots.try_reserve(needed)
     }
 
     /// Returns `true` if the slot map contains `key`.

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -2,8 +2,9 @@
 
 use super::{is_older_version, Key, KeyData};
 use std;
-use std::collections::hash_map;
-use std::collections::hash_map::HashMap;
+use std::collections::hash_map::{self, HashMap};
+#[cfg(feature = "unstable")]
+use std::collections::CollectionAllocErr;
 use std::iter::{Extend, FromIterator, FusedIterator};
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
@@ -173,6 +174,24 @@ impl<K: Key, V> SparseSecondaryMap<K, V> {
     /// ```
     pub fn reserve(&mut self, additional: usize) {
         self.slots.reserve(additional);
+    }
+
+    /// Tries to reserve capacity for at least `additional` more slots in the
+    /// `SparseSecondaryMap`.  The collection may reserve more space to avoid
+    /// frequent reallocations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sec: SparseSecondaryMap<DefaultKey, i32> = SparseSecondaryMap::with_capacity(10);
+    /// assert!(sec.capacity() >= 10);
+    /// sec.try_reserve(10).unwrap();
+    /// assert!(sec.capacity() >= 20);
+    /// ```
+    #[cfg(feature = "unstable")]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+        self.slots.try_reserve(additional)
     }
 
     /// Returns `true` if the secondary map contains `key`.


### PR DESCRIPTION
This will need to be tweaked from `std::collections::CollectionAllocErr` to `crate::alloc::collections::CollectionAllocErr` if #18 is accepted.

This is the only conflict between my 4 split PRs.