### PR TITLE
No std (extends 2018 edition)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ keywords = ["slotmap", "storage", "allocator", "stable", "reference"]
 categories = ["data-structures", "memory-management", "caching"]
 
 [features]
+default = ["std"]
+serde-alloc = ["serde/alloc"]
+serde-std = ["serde/std"]
+std = []
 unstable = []
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 serde = "1.0"

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -12,14 +12,16 @@
 //! The trade-off is that compared to a regular `SlotMap` insertion/removal is
 //! roughly twice as slow. Random indexing has identical performance for both.
 
-use std;
-use std::iter::FusedIterator;
-use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
-use std::ops::{Index, IndexMut};
-use std::{fmt, ptr};
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ops::{Index, IndexMut};
+use core::{fmt, ptr};
+
+#[cfg(not(feature = "std"))]
+use crate::alloc::prelude::*;
 #[cfg(feature = "unstable")]
-use std::collections::CollectionAllocErr;
+use crate::alloc::collections::CollectionAllocErr;
 
 use crate::{DefaultKey, Key, KeyData, Slottable};
 
@@ -88,7 +90,7 @@ impl<T: Slottable> Slot<T> {
 
 impl<T: Slottable> Drop for Slot<T> {
     fn drop(&mut self) {
-        if std::mem::needs_drop::<T>() && self.occupied() {
+        if core::mem::needs_drop::<T>() && self.occupied() {
             // This is safe because we checked that we're occupied.
             unsafe {
                 ManuallyDrop::drop(&mut self.u.value);
@@ -375,7 +377,7 @@ impl<K: Key, V: Slottable> HopSlotMap<K, V> {
     {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
-        if new_num_elems == std::u32::MAX {
+        if new_num_elems == core::u32::MAX {
             panic!("HopSlotMap number of elements overflow");
         }
 
@@ -455,7 +457,7 @@ impl<K: Key, V: Slottable> HopSlotMap<K, V> {
         // contiguous block to the left or right, merging the two blocks to the
         // left and right or inserting a new block.
         let i = idx as u32;
-        // use std::hint::unreachable_unchecked;
+        // use core::hint::unreachable_unchecked;
 
         match (left_vacant, right_vacant) {
             (false, false) => {

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -3,14 +3,16 @@
 
 //! Contains the slot map implementation.
 
-use std;
-use std::iter::{Enumerate, FusedIterator};
-use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
-use std::ops::{Index, IndexMut};
-use std::{fmt, ptr};
+use core::iter::{Enumerate, FusedIterator};
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ops::{Index, IndexMut};
+use core::{fmt, ptr};
+
+#[cfg(not(feature = "std"))]
+use crate::alloc::prelude::*;
 #[cfg(feature = "unstable")]
-use std::collections::CollectionAllocErr;
+use crate::alloc::collections::CollectionAllocErr;
 
 use crate::{DefaultKey, Key, KeyData, Slottable};
 
@@ -71,7 +73,7 @@ impl<T: Slottable> Slot<T> {
 
 impl<T: Slottable> Drop for Slot<T> {
     fn drop(&mut self) {
-        if std::mem::needs_drop::<T>() && self.occupied() {
+        if core::mem::needs_drop::<T>() && self.occupied() {
             // This is safe because we checked that we're occupied.
             unsafe {
                 ManuallyDrop::drop(&mut self.u.value);
@@ -350,7 +352,7 @@ impl<K: Key, V: Slottable> SlotMap<K, V> {
     {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
-        if new_num_elems == std::u32::MAX {
+        if new_num_elems == core::u32::MAX {
             panic!("SlotMap number of elements overflow");
         }
 
@@ -791,7 +793,7 @@ pub struct Drain<'a, K: 'a + Key, V: 'a + Slottable> {
 #[derive(Debug)]
 pub struct IntoIter<K: Key, V: Slottable> {
     num_left: usize,
-    slots: Enumerate<std::vec::IntoIter<Slot<V>>>,
+    slots: Enumerate<crate::alloc::vec::IntoIter<Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -799,7 +801,7 @@ pub struct IntoIter<K: Key, V: Slottable> {
 #[derive(Debug)]
 pub struct Iter<'a, K: 'a + Key, V: 'a + Slottable> {
     num_left: usize,
-    slots: Enumerate<std::slice::Iter<'a, Slot<V>>>,
+    slots: Enumerate<crate::alloc::slice::Iter<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -807,7 +809,7 @@ pub struct Iter<'a, K: 'a + Key, V: 'a + Slottable> {
 #[derive(Debug)]
 pub struct IterMut<'a, K: 'a + Key, V: 'a + Slottable> {
     num_left: usize,
-    slots: Enumerate<std::slice::IterMut<'a, Slot<V>>>,
+    slots: Enumerate<crate::alloc::slice::IterMut<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -1,13 +1,16 @@
 //! Contains the secondary map implementation.
 
 use super::{is_older_version, Key, KeyData};
-use std;
-use std::hint::unreachable_unchecked;
-use std::iter::{Enumerate, Extend, FromIterator, FusedIterator};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+
+use core::hint::unreachable_unchecked;
+use core::iter::{Enumerate, Extend, FromIterator, FusedIterator};
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut};
+
+#[cfg(not(feature = "std"))]
+use crate::alloc::prelude::*;
 #[cfg(feature = "unstable")]
-use std::collections::CollectionAllocErr;
+use crate::alloc::collections::CollectionAllocErr;
 
 // We could use unions to remove the memory overhead of Option here as well, but
 // until non-Copy elements inside unions stabilize it's better to give users at
@@ -281,7 +284,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
 
         let slot = &mut self.slots[key.idx as usize];
         if slot.version == key.version.get() {
-            return std::mem::replace(&mut slot.value, Some(value));
+            return core::mem::replace(&mut slot.value, Some(value));
         }
 
         if slot.occupied() {
@@ -336,7 +339,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
                 // denied as outdated.
                 slot.version -= 1;
                 self.num_elems -= 1;
-                return Some(std::mem::replace(&mut slot.value, None).unwrap());
+                return Some(core::mem::replace(&mut slot.value, None).unwrap());
             }
         }
 
@@ -773,7 +776,7 @@ pub struct Drain<'a, K: Key + 'a, V: 'a> {
 #[derive(Debug)]
 pub struct IntoIter<K: Key, V> {
     num_left: usize,
-    slots: Enumerate<std::vec::IntoIter<Slot<V>>>,
+    slots: Enumerate<crate::alloc::vec::IntoIter<Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -781,7 +784,7 @@ pub struct IntoIter<K: Key, V> {
 #[derive(Debug)]
 pub struct Iter<'a, K: Key + 'a, V: 'a> {
     num_left: usize,
-    slots: Enumerate<std::slice::Iter<'a, Slot<V>>>,
+    slots: Enumerate<core::slice::Iter<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -789,7 +792,7 @@ pub struct Iter<'a, K: Key + 'a, V: 'a> {
 #[derive(Debug)]
 pub struct IterMut<'a, K: Key + 'a, V: 'a> {
     num_left: usize,
-    slots: Enumerate<std::slice::IterMut<'a, Slot<V>>>,
+    slots: Enumerate<core::slice::IterMut<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -820,7 +823,7 @@ impl<'a, K: Key, V> Iterator for Drain<'a, K, V> {
             let idx = self.cur;
             self.cur += 1;
 
-            if let Some(value) = std::mem::replace(&mut self.sm.slots[idx].value, None) {
+            if let Some(value) = core::mem::replace(&mut self.sm.slots[idx].value, None) {
                 let key = KeyData::new(idx as u32, self.sm.slots[idx].version);
                 self.sm.slots[idx].version -= 1;
                 self.sm.num_elems -= 1;
@@ -848,7 +851,7 @@ impl<K: Key, V> Iterator for IntoIter<K, V> {
 
     fn next(&mut self) -> Option<(K, V)> {
         while let Some((idx, mut slot)) = self.slots.next() {
-            if let Some(value) = std::mem::replace(&mut slot.value, None) {
+            if let Some(value) = core::mem::replace(&mut slot.value, None) {
                 let key = KeyData::new(idx as u32, slot.version);
                 self.num_left -= 1;
                 return Some((key.into(), value));

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -1,14 +1,16 @@
 //! Contains the sparse secondary map implementation.
 
 use super::{is_older_version, Key, KeyData};
-use std::hash;
-use std::collections::hash_map::{self, HashMap};
-use std::iter::{Extend, FromIterator, FusedIterator};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+
+use core::iter::{Extend, FromIterator, FusedIterator};
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut};
+use core::hash;
+
+use crate::alloc::collections::hash_map::{self, HashMap};
 
 #[cfg(feature = "unstable")]
-use std::collections::CollectionAllocErr;
+use crate::alloc::collections::CollectionAllocErr;
 
 #[derive(Debug)]
 struct Slot<T> {
@@ -283,7 +285,7 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
 
         if let Some(slot) = self.slots.get_mut(&key.idx) {
             if slot.version == key.version.get() {
-                return Some(std::mem::replace(&mut slot.value, value));
+                return Some(core::mem::replace(&mut slot.value, value));
             }
 
             // Don't replace existing newer values.


### PR DESCRIPTION
Messing with the imports for 2015 edition is more annoying for no_std and my attempts failed. Sure it can be done, but it isn't worth it as there is no reason against using the 2018 edition.

Blocking on #16.