### PR TITLE
Add Entry API to SecondaryMap

### DIFF
--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -1071,7 +1071,7 @@ impl<'a, K: Key, V> OccupiedEntry<'a, K, V> {
         let slot = unsafe { self.map.slots.get_unchecked_mut(keyd.idx as usize) };
         slot.version -= 1;
         self.map.num_elems -= 1;
-        match std::mem::replace(&mut slot.value, None) {
+        match slot.value.take() {
             Some(x) => x,
             None => unsafe { unreachable_unchecked() },
         }
@@ -1166,10 +1166,7 @@ impl<'a, K: Key, V> VacantEntry<'a, K, V> {
             value: Some(value),
         };
 
-        match slot.value.as_mut() {
-            Some(x) => x,
-            None => unsafe { unreachable_unchecked() },
-        }
+        slot.value.as_mut().unwrap()
     }
 }
 

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -712,17 +712,11 @@ impl<K: Key, V> SecondaryMap<K, V> {
                 return None;
             }
             if slot.version == v {
-                return Some(Entry::Occupied(OccupiedEntry {
-                    map: self,
-                    key,
-                }));
+                return Some(Entry::Occupied(OccupiedEntry { map: self, key }));
             }
         }
 
-        Some(Entry::Vacant(VacantEntry {
-            map: self,
-            key,
-        }))
+        Some(Entry::Vacant(VacantEntry { map: self, key }))
     }
 }
 
@@ -890,8 +884,9 @@ impl<'a, K: Key, V> Entry<'a, K, V> {
     /// assert_eq!(sec[k], 1)
     /// ```
     pub fn and_modify<F>(mut self, f: F) -> Self
-        where
-            F: for<'b> FnOnce(&'b mut V) {
+    where
+        F: for<'b> FnOnce(&'b mut V),
+    {
         if let Entry::Occupied(o) = &mut self {
             f(o.get_mut());
         }
@@ -949,31 +944,6 @@ impl<'a, K: Key, V> OccupiedEntry<'a, K, V> {
     /// ```
     pub fn key(&self) -> &K {
         &self.key
-    }
-
-    /// Take the ownership of the key and value from the map.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slotmap::*;
-    /// # use slotmap::secondary::Entry;
-    ///
-    /// let mut sm = SlotMap::new();
-    /// let mut sec = SecondaryMap::new();
-    ///
-    /// let k = sm.insert(1);
-    /// sec.insert(k, 10);
-    ///
-    /// if let Entry::Occupied(o) = sec.entry(k).unwrap() {
-    ///     let (k, v) = o.remove_entry();
-    ///     assert_eq!(v, 10);
-    ///     assert_eq!(sec.get(k), None);
-    /// }
-    /// ```
-    pub fn remove_entry(self) -> (K, V) {
-        let v = self.map.remove(self.key.clone()).unwrap();
-        (self.key, v)
     }
 
     /// Gets a reference to the value in the entry.
@@ -1103,7 +1073,7 @@ impl<'a, K: Key, V> OccupiedEntry<'a, K, V> {
         self.map.num_elems -= 1;
         match std::mem::replace(&mut slot.value, None) {
             Some(x) => x,
-            None => unsafe { unreachable_unchecked() }
+            None => unsafe { unreachable_unchecked() },
         }
     }
 }
@@ -1181,7 +1151,8 @@ impl<'a, K: Key, V> VacantEntry<'a, K, V> {
     /// ```
     pub fn insert(self, value: V) -> &'a mut V {
         let key = self.key.into();
-        self.map.slots
+        self.map
+            .slots
             .extend((self.map.slots.len()..=key.idx as usize).map(|_| Slot {
                 version: 0,
                 value: None,
@@ -1197,7 +1168,7 @@ impl<'a, K: Key, V> VacantEntry<'a, K, V> {
 
         match slot.value.as_mut() {
             Some(x) => x,
-            None => unsafe { unreachable_unchecked() }
+            None => unsafe { unreachable_unchecked() },
         }
     }
 }

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -794,12 +794,18 @@ impl<'a, K: Key, V: 'a + Copy> Extend<(K, &'a V)> for SecondaryMap<K, V> {
     }
 }
 
-/// An Entry API
+/// A view into a single entry in a SecondaryMap, which may either be vacant or occupied.
+///
+/// This `enum` is constructed from the [`entry`] method on [`SecondaryMap`].
+///
+/// [`SecondaryMap`]: struct.SecondaryMap.html
+/// [`entry`]: struct.SecondaryMap.html#method.entry
 #[derive(Debug)]
 pub enum Entry<'a, K: Key, V> {
-    /// The Occupied variant
+    /// An occupied entry
     Occupied(OccupiedEntry<'a, K, V>),
-    /// The Vacant variant
+
+    /// A vacant entry
     Vacant(VacantEntry<'a, K, V>),
 }
 
@@ -924,7 +930,7 @@ impl<'a, K: Key, V: Default> Entry<'a, K, V> {
 }
 
 /// A view into a occupied entry in a `SecondaryMap`.
-/// It is part of the [`Entry`] enum.
+/// It is part of the `Entry` enum.
 #[derive(Debug)]
 pub struct OccupiedEntry<'a, K: Key, V> {
     map: &'a mut SecondaryMap<K, V>,
@@ -1107,7 +1113,7 @@ impl<'a, K: Key, V> OccupiedEntry<'a, K, V> {
 }
 
 /// A view into a vacant entry in a `SecondaryMap`.
-/// It is part of the [`Entry`] enum.
+/// It is part of the `Entry` enum.
 #[derive(Debug)]
 pub struct VacantEntry<'a, K: Key, V> {
     map: &'a mut SecondaryMap<K, V>,

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -689,6 +689,41 @@ impl<K: Key, V> SecondaryMap<K, V> {
             inner: self.iter_mut(),
         }
     }
+
+    /// Gets the given key's corresponding entry in the map for in-place manipulation.
+    /// Returns None if the key is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    /// let k = sm.insert(1);
+    /// let v = sec.entry(k).unwrap().or_insert(10);
+    /// assert_eq!(*v, 10);
+    /// ```
+    pub fn entry(&mut self, key: K) -> Option<Entry<K, V>> {
+        let keyd = key.clone().into();
+
+        if let Some(slot) = self.slots.get_mut(keyd.idx as usize) {
+            let v = keyd.version.get();
+            if is_older_version(v, slot.version) {
+                return None;
+            }
+            if slot.version == v {
+                return Some(Entry::Occupied(OccupiedEntry {
+                    map: self,
+                    key,
+                }));
+            }
+        }
+
+        Some(Entry::Vacant(VacantEntry {
+            map: self,
+            key,
+        }))
+    }
 }
 
 impl<K: Key, V> Default for SecondaryMap<K, V> {
@@ -756,6 +791,395 @@ impl<'a, K: Key, V: 'a + Copy> Extend<(K, &'a V)> for SecondaryMap<K, V> {
         for (k, v) in iter {
             self.insert(k, *v);
         }
+    }
+}
+
+/// An Entry API
+#[derive(Debug)]
+pub enum Entry<'a, K: Key, V> {
+    /// The Occupied variant
+    Occupied(OccupiedEntry<'a, K, V>),
+    /// The Vacant variant
+    Vacant(VacantEntry<'a, K, V>),
+}
+
+impl<'a, K: Key, V> Entry<'a, K, V> {
+    /// Ensures a value is in the entry by inserting the default if empty, and returns
+    /// a mutable reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// let v = sec.entry(k).unwrap().or_insert(10);
+    ///
+    /// assert_eq!(v, &10);
+    /// ```
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        match self {
+            Entry::Occupied(x) => x.into_mut(),
+            Entry::Vacant(x) => x.insert(default),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the result of the default function if empty,
+    /// and returns a mutable reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// let v = sec.entry(k).unwrap().or_insert_with(|| "foobar".to_string());
+    ///
+    /// assert_eq!(v, &"foobar");
+    /// ```
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        match self {
+            Entry::Occupied(x) => x.into_mut(),
+            Entry::Vacant(x) => x.insert(default()),
+        }
+    }
+
+    /// Returns a reference to this entry's key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let mut sec: SecondaryMap<_, ()> = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// let entry = sec.entry(k).unwrap();
+    /// let k2 = entry.key();
+    ///
+    /// assert_eq!(k2, &k);
+    /// ```
+    pub fn key(&self) -> &K {
+        match self {
+            Entry::Occupied(ref entry) => entry.key(),
+            Entry::Vacant(ref entry) => entry.key(),
+        }
+    }
+
+    /// Provides in-place mutable access to an occupied entry before any
+    /// potential inserts into the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 0);
+    /// sec.entry(k).unwrap().and_modify(|x| *x = 1);
+    ///
+    /// assert_eq!(sec[k], 1)
+    /// ```
+    pub fn and_modify<F>(self, f: F) -> Self
+        where
+            F: for<'b> FnOnce(&'b mut V) {
+        match self {
+            Entry::Occupied(mut x) => {
+                f(x.get_mut());
+                Entry::Occupied(x)
+            }
+            e @ Entry::Vacant(_) => e,
+        }
+    }
+}
+
+impl<'a, K: Key, V: Default> Entry<'a, K, V> {
+    /// Ensures a value is in the entry by inserting the default value if empty,
+    /// and returns a mutable reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let mut sec: SecondaryMap<_, Option<i32>> = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.entry(k).unwrap().or_default();
+    ///
+    /// assert_eq!(sec[k], None)
+    /// ```
+    pub fn or_default(self) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Default::default()),
+        }
+    }
+}
+
+/// A view into a occupied entry in a `SecondaryMap`.
+/// It is part of the [`Entry`] enum.
+#[derive(Debug)]
+pub struct OccupiedEntry<'a, K: Key, V> {
+    map: &'a mut SecondaryMap<K, V>,
+    key: K,
+}
+
+impl<'a, K: Key, V> OccupiedEntry<'a, K, V> {
+    /// Gets a reference to the key in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 10);
+    ///
+    /// if let Entry::Occupied(o) = sec.entry(k).unwrap() {
+    ///     assert_eq!(o.key(), &k);
+    /// }
+    /// ```
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    /// Take the ownership of the key and value from the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 10);
+    ///
+    /// if let Entry::Occupied(o) = sec.entry(k).unwrap() {
+    ///     let (k, v) = o.remove_entry();
+    ///     assert_eq!(v, 10);
+    ///     assert_eq!(sec.get(k), None);
+    /// }
+    /// ```
+    pub fn remove_entry(self) -> (K, V) {
+        let v = self.map.remove(self.key.clone()).unwrap();
+        (self.key, v)
+    }
+
+    /// Gets a reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 10);
+    ///
+    /// if let Entry::Occupied(o) = sec.entry(k).unwrap() {
+    ///     assert_eq!(o.get(), &10);
+    /// }
+    /// ```
+    pub fn get(&self) -> &V {
+        unsafe { self.map.get_unchecked(self.key.clone()) }
+    }
+
+    /// Gets a mutable reference to the value in the entry.
+    ///
+    /// If you need a reference to the OccupiedEntry which may outlive the destruction of the Entry value, see into_mut.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 10);
+    ///
+    /// if let Entry::Occupied(mut o) = sec.entry(k).unwrap() {
+    ///     *o.get_mut() = 20;
+    ///     assert_eq!(o.get(), &20);
+    /// }
+    /// ```
+    pub fn get_mut(&mut self) -> &mut V {
+        unsafe { self.map.get_unchecked_mut(self.key.clone()) }
+    }
+
+    /// Converts the OccupiedEntry into a mutable reference to the value in the entry with a lifetime bound to the map itself.
+    ///
+    /// If you need multiple references to the OccupiedEntry, see get_mut.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(2);
+    /// sec.insert(k, 0);
+    ///
+    /// let mut v = &mut 3;
+    /// if let Entry::Occupied(o) = sec.entry(k).unwrap() {
+    ///     v = o.into_mut(); // v outlives the entry
+    /// }
+    ///
+    /// *v = 1;
+    ///
+    /// assert_eq!(sec[k], 1);
+    /// ```
+    pub fn into_mut(self) -> &'a mut V {
+        unsafe { self.map.get_unchecked_mut(self.key) }
+    }
+
+    /// Sets the value of the entry, and returns the entry's old value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 10);
+    ///
+    /// if let Entry::Occupied(mut o) = sec.entry(k).unwrap() {
+    ///     let v = o.insert(20);
+    ///     assert_eq!(v, 10);
+    ///     assert_eq!(o.get(), &20);
+    /// }
+    /// ```
+    pub fn insert(&mut self, mut value: V) -> V {
+        let old_value = self.get_mut();
+        std::mem::swap(&mut value, old_value);
+        value
+    }
+
+    /// Takes the value out of the entry, and returns it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    /// sec.insert(k, 10);
+    ///
+    /// if let Entry::Occupied(mut o) = sec.entry(k).unwrap() {
+    ///     let v = o.remove();
+    ///     assert_eq!(v, 10);
+    ///     assert_eq!(sec.get(k), None);
+    /// }
+    /// ```
+    pub fn remove(self) -> V {
+        self.map.remove(self.key).unwrap()
+    }
+}
+
+/// A view into a vacant entry in a `SecondaryMap`.
+/// It is part of the [`Entry`] enum.
+#[derive(Debug)]
+pub struct VacantEntry<'a, K: Key, V> {
+    map: &'a mut SecondaryMap<K, V>,
+    key: K,
+}
+
+impl<'a, K: Key, V> VacantEntry<'a, K, V> {
+    /// Gets a reference to the key that would be used when inserting a value
+    /// through the `VacantEntry`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec: SecondaryMap<_, ()> = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    ///
+    /// if let Entry::Vacant(v) = sec.entry(k).unwrap() {
+    ///     assert_eq!(v.key(), &k);
+    /// }
+    /// ```
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    /// Take ownership of the key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec: SecondaryMap<_, ()> = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    ///
+    /// if let Entry::Vacant(v) = sec.entry(k).unwrap() {
+    ///     assert_eq!(v.into_key(), k);
+    /// }
+    /// ```
+    pub fn into_key(self) -> K {
+        self.key
+    }
+
+    /// Sets the value of the entry with the VacantEntry's key,
+    /// and returns a mutable reference to it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use slotmap::secondary::Entry;
+    ///
+    /// let mut sm = SlotMap::new();
+    /// let mut sec = SecondaryMap::new();
+    ///
+    /// let k = sm.insert(1);
+    ///
+    /// if let Entry::Vacant(v) = sec.entry(k).unwrap() {
+    ///     let new_val = v.insert(3);
+    ///     assert_eq!(new_val, &mut 3);
+    /// }
+    /// ```
+    pub fn insert(self, value: V) -> &'a mut V {
+        self.map.insert(self.key.clone(), value);
+        unsafe { self.map.get_unchecked_mut(self.key) }
     }
 }
 


### PR DESCRIPTION
Adding an Entry API for SecondaryMap makes a lot of sense (less than for SlotMap which is harder since you have to pass the generated key back to the user somehow).
It's pretty much the same API as for HashMap.    

This is still a draft as I have to add some tests and some doc, but I would still appreciate an early review. First of all, to check if you're actually interested with this kind of API, and also because you could've had another idea in mind. 

Partially Fixes #29 