### PR TITLE
provide Keydata.get_idx_version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,18 @@ impl KeyData {
         let version = (value >> 32) | 1; // Ensure version is odd.
         Self::new(idx as u32, version as u32)
     }
+
+    /// Returns the slot index and version.  This is useful only in
+    /// unusual situations.  At any one time, a slotmap has at most
+    /// one entry with each index.  The combination of index and
+    /// version are unique across time.  Indices are generally not
+    /// significantly bigger than thw maximum ever occupancy.  No
+    /// other guarantees are made.
+    ///
+    /// For serialisation, use `serde` or `as_ffi`.
+    pub fn get_idx_version(self) -> (u32, u32) {
+        (self.idx, self.version.get())
+    }
 }
 
 impl Debug for KeyData {


### PR DESCRIPTION
Hi.  I really like this crate.  Thanks.

I had one small issue that I think would be best addressed by adding a new getter on KeyData.  My MR leaks the abstraction a bit more (about as much as the Debug impl does) but in my situation it would be quite useful.  To motivate, I will explain:

I'm writing a game system. Players in a game may come and go but there will be few at any one time.  I'm already using SlotMap for my record of the players.

I want to have something like a "player number" visible to the users: there's a player nickname but in one circumstance (a graphical representation) I really want something much terser.  A small integer would be ideal.  (Player 1 etc.)

Slotmap has that internally of course.  But right now it's hidden.  My options are 1. make a new data structure very similar to SlotMap 2. abuse KeyData.as_ffi 3. Add a method to get the slot index.

It seems to me that 3 is the right answer so here is my MR.  I hope you like it.  I wasn't quite sure what name and precise API you would like but this one seems OK to me.  Returning the version as well is potentially a tiny bit wasteful and/or irrelevant, but it does make the doc exposition a lot easier.

I have noticed that DenseSlotMap doesn't seem to use index 0.  I didn't add a guarantee that the index would be nonzero for a real entry.  Should I add that to the doc?