### PR TITLE
Only apply the `unstable` feature on nightly toolchains.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 quickcheck = "0.8"
+
+[build-dependencies]
+rustversion = "1.0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+#[rustversion::not(nightly)]
+fn main() {}
+
+#[rustversion::nightly]
+fn main() {
+    println!("cargo:rustc-cfg=nightly");
+}

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -7,7 +7,7 @@
 // might have come from a different slot map or malicious serde deseralization).
 
 use std;
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 use std::collections::TryReserveError;
 use std::iter::FusedIterator;
 use std::ops::{Index, IndexMut};
@@ -202,7 +202,7 @@ impl<K: Key, V> DenseSlotMap<K, V> {
     /// sm.try_reserve(32).unwrap();
     /// assert!(sm.capacity() >= 33);
     /// ```
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.keys.try_reserve(additional)?;
         self.values.try_reserve(additional)?;

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -13,7 +13,7 @@
 //! roughly twice as slow. Random indexing has identical performance for both.
 
 use std;
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 use std::collections::TryReserveError;
 use std::iter::FusedIterator;
 use std::marker::PhantomData;
@@ -299,7 +299,7 @@ impl<K: Key, V: Slottable> HopSlotMap<K, V> {
     /// sm.try_reserve(32).unwrap();
     /// assert!(sm.capacity() >= 33);
     /// ```
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         // One slot is reserved for the freelist sentinel.
         let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
@@ -1282,7 +1282,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use serde_json;
 
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     #[test]
     fn check_drops() {
         let drops = std::cell::RefCell::new(0usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/slotmap/0.4.0")]
 #![crate_name = "slotmap"]
-#![cfg_attr(feature = "unstable", feature(untagged_unions, try_reserve))]
+#![cfg_attr(
+    all(nightly, feature = "unstable"),
+    feature(untagged_unions, try_reserve)
+)]
 
 //! # slotmap
 //!
@@ -220,7 +223,7 @@ use std::num::NonZeroU32;
 /// [`SlotMap`]: struct.SlotMap.html
 /// [`HopSlotMap`]: hop/struct.HopSlotMap.html
 /// [`DenseSlotMap`]: dense/struct.DenseSlotMap.html
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(all(nightly, feature = "unstable")))]
 pub trait Slottable: Copy {}
 
 /// A trait for items that can go in a [`SlotMap`] or [`HopSlotMap`]. Due to
@@ -243,13 +246,13 @@ pub trait Slottable: Copy {}
 /// [`SlotMap`]: struct.SlotMap.html
 /// [`HopSlotMap`]: hop/struct.HopSlotMap.html
 /// [`DenseSlotMap`]: dense/struct.DenseSlotMap.html
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 pub trait Slottable {}
 
-#[cfg(not(feature = "unstable"))]
+#[cfg(not(all(nightly, feature = "unstable")))]
 impl<T: Copy> Slottable for T {}
 
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 impl<T> Slottable for T {}
 
 /// The actual data stored in a [`Key`].

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -4,7 +4,7 @@
 //! Contains the slot map implementation.
 
 use std;
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 use std::collections::TryReserveError;
 use std::iter::{Enumerate, FusedIterator};
 use std::marker::PhantomData;
@@ -281,7 +281,7 @@ impl<K: Key, V: Slottable> SlotMap<K, V> {
     /// sm.try_reserve(32).unwrap();
     /// assert!(sm.capacity() >= 33);
     /// ```
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         // One slot is reserved for the sentinel.
         let needed = (self.len() + additional).saturating_sub(self.slots.len() - 1);
@@ -1129,7 +1129,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use serde_json;
 
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     #[test]
     fn check_drops() {
         let drops = std::cell::RefCell::new(0usize);

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -2,7 +2,7 @@
 
 use super::{is_older_version, Key, KeyData};
 use std;
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 use std::collections::TryReserveError;
 use std::hint::unreachable_unchecked;
 use std::iter::{Enumerate, Extend, FromIterator, FusedIterator};
@@ -220,7 +220,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// sec.try_set_capacity(1000).unwrap();
     /// assert!(sec.capacity() >= 1000);
     /// ```
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     pub fn try_set_capacity(&mut self, new_capacity: usize) -> Result<(), TryReserveError> {
         let new_capacity = new_capacity + 1; // Sentinel.
         if new_capacity > self.slots.capacity() {

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -7,7 +7,7 @@ use std::iter::{Extend, FromIterator, FusedIterator};
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 
-#[cfg(feature = "unstable")]
+#[cfg(all(nightly, feature = "unstable"))]
 use std::collections::TryReserveError;
 
 #[derive(Debug, Clone)]
@@ -234,7 +234,7 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
     /// sec.try_reserve(10).unwrap();
     /// assert!(sec.capacity() >= 10);
     /// ```
-    #[cfg(feature = "unstable")]
+    #[cfg(all(nightly, feature = "unstable"))]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.slots.try_reserve(additional)
     }


### PR DESCRIPTION
The `unstable` feature interacts poorly with non-nightly toolchains and Cargo options (in particular `--all-features`). Building `slotmap` with `cargo build --all-features` causes errors when using a stable toolchain, for example. This change uses a build script to detect nightly toolchains and further gates the `unstable` feature on a `nightly` configuration. This prevents errors caused by using the `feature` attribute with non-nightly toolchains.

The use of [`rustversion`] in a build script is a known pattern. See that crate for more. Please take a look. Thanks!

[`rustversion`]: https://crates.io/crates/rustversion