### PR TITLE
Added clone_from implementations for all slotmaps

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -93,6 +93,16 @@ impl<T: Clone> Clone for Slot<T> {
             version: self.version,
         }
     }
+
+    fn clone_from(&mut self, source: &Self) {
+        match (self.get_mut(), source.get()) {
+            (OccupiedMut(self_val), Occupied(source_val)) => self_val.clone_from(source_val),
+            (VacantMut(self_val), Vacant(&source_val)) => *self_val = source_val,
+            (_, Occupied(value)) => self.u = SlotUnion{ value: ManuallyDrop::new(value.clone()) },
+            (_, Vacant(&next_free)) => self.u = SlotUnion{ next_free },
+        }
+        self.version = source.version;
+    }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Slot<T> {
@@ -109,7 +119,7 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 /// Slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SlotMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     free_head: u32,
@@ -850,6 +860,24 @@ impl<K: Key, V> SlotMap<K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
+    }
+}
+
+impl<K: Key, V> Clone for SlotMap<K, V>
+where
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            slots: self.slots.clone(),
+            ..*self
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.slots.clone_from(&source.slots);
+        self.free_head = source.free_head;
+        self.num_elems = source.num_elems;
     }
 }
 

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -30,7 +30,7 @@ struct Slot {
 /// Dense slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DenseSlotMap<K: Key, V> {
     keys: Vec<K>,
     values: Vec<V>,
@@ -757,6 +757,27 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
+    }
+}
+
+impl<K: Key, V> Clone for DenseSlotMap<K, V>
+where
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            keys: self.keys.clone(),
+            values: self.values.clone(),
+            slots: self.slots.clone(),
+            ..*self
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.keys.clone_from(&source.keys);
+        self.values.clone_from(&source.values);
+        self.slots.clone_from(&source.slots);
+        self.free_head = source.free_head;
     }
 }
 

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -113,6 +113,16 @@ impl<T: Clone> Clone for Slot<T> {
             version: self.version,
         }
     }
+
+    fn clone_from(&mut self, source: &Self) {
+        match (self.get_mut(), source.get()) {
+            (OccupiedMut(self_val), Occupied(source_val)) => self_val.clone_from(source_val),
+            (VacantMut(self_val), Vacant(&source_val)) => *self_val = source_val,
+            (_, Occupied(value)) => self.u = SlotUnion{ value: ManuallyDrop::new(value.clone()) },
+            (_, Vacant(&free)) => self.u = SlotUnion{ free },
+        }
+        self.version = source.version;
+    }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Slot<T> {
@@ -129,7 +139,7 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 /// Hop slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct HopSlotMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     num_elems: u32,
@@ -939,6 +949,20 @@ impl<K: Key, V> HopSlotMap<K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
+    }
+}
+
+impl<K: Key, V> Clone for HopSlotMap<K, V> where V: Clone{
+    fn clone(&self) -> Self {
+        Self{
+            slots: self.slots.clone(),
+            ..*self
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.slots.clone_from(&source.slots);
+        self.num_elems = source.num_elems;
     }
 }
 


### PR DESCRIPTION
`#[derive(Clone)]` does not provide a `clone_from` implementation, only clone. This PR adds the `clone_from` implementations to increase performance where this function can be used. All relevant slots also received implementations because that's where the data is actually stored.