### PR TITLE
Replace over-restrictive #[derive(Clone)] on iterators with manual Clone impls

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -906,11 +906,21 @@ pub struct IntoIter<K: Key, V> {
 /// An iterator over the key-value pairs in a [`SlotMap`].
 ///
 /// This iterator is created by [`SlotMap::iter`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, K: 'a + Key, V: 'a> {
     num_left: usize,
     slots: Enumerate<core::slice::Iter<'a, Slot<V>>>,
     _k: PhantomData<fn(K) -> K>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter {
+            num_left: self.num_left,
+            slots: self.slots.clone(),
+            _k: self._k
+        }
+    }
 }
 
 /// A mutable iterator over the key-value pairs in a [`SlotMap`].
@@ -926,17 +936,33 @@ pub struct IterMut<'a, K: 'a + Key, V: 'a> {
 /// An iterator over the keys in a [`SlotMap`].
 ///
 /// This iterator is created by [`SlotMap::keys`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Keys<'a, K: 'a + Key, V: 'a> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Keys<'a, K, V> {
+    fn clone(&self) -> Self {
+        Keys {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// An iterator over the values in a [`SlotMap`].
 ///
 /// This iterator is created by [`SlotMap::values`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Values<'a, K: 'a + Key, V: 'a> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Values<'a, K, V> {
+    fn clone(&self) -> Self {
+        Values {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the values in a [`SlotMap`].

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -810,10 +810,19 @@ pub struct IntoIter<K, V> {
 /// An iterator over the key-value pairs in a [`DenseSlotMap`].
 ///
 /// This iterator is created by [`DenseSlotMap::iter`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, K: 'a + Key, V: 'a> {
     inner_keys: core::slice::Iter<'a, K>,
     inner_values: core::slice::Iter<'a, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter {
+            inner_keys: self.inner_keys.clone(),
+            inner_values: self.inner_values.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the key-value pairs in a [`DenseSlotMap`].
@@ -828,17 +837,33 @@ pub struct IterMut<'a, K: 'a + Key, V: 'a> {
 /// An iterator over the keys in a [`DenseSlotMap`].
 ///
 /// This iterator is created by [`DenseSlotMap::keys`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Keys<'a, K: 'a + Key, V> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Keys<'a, K, V> {
+    fn clone(&self) -> Self {
+        Keys {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// An iterator over the values in a [`DenseSlotMap`].
 ///
 /// This iterator is created by [`DenseSlotMap::values`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Values<'a, K: 'a + Key, V> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Values<'a, K, V> {
+    fn clone(&self) -> Self {
+        Values {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the values in a [`DenseSlotMap`].

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -996,12 +996,23 @@ pub struct IntoIter<K: Key, V> {
 /// An iterator over the key-value pairs in a [`HopSlotMap`].
 ///
 /// This iterator is created by [`HopSlotMap::iter`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, K: Key + 'a, V: 'a> {
     cur: usize,
     num_left: usize,
     slots: &'a [Slot<V>],
     _k: PhantomData<fn(K) -> K>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter {
+            cur: self.cur,
+            num_left: self.num_left,
+            slots: self.slots,
+            _k: self._k.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the key-value pairs in a [`HopSlotMap`].
@@ -1018,17 +1029,33 @@ pub struct IterMut<'a, K: Key + 'a, V: 'a> {
 /// An iterator over the keys in a [`HopSlotMap`].
 ///
 /// This iterator is created by [`HopSlotMap::keys`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Keys<'a, K: Key + 'a, V: 'a> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Keys<'a, K, V> {
+    fn clone(&self) -> Self {
+        Keys {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// An iterator over the values in a [`HopSlotMap`].
 ///
 /// This iterator is created by [`HopSlotMap::values`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Values<'a, K: Key + 'a, V: 'a> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Values<'a, K, V> {
+    fn clone(&self) -> Self {
+        Values {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the values in a [`HopSlotMap`].

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -1320,6 +1320,16 @@ pub struct Iter<'a, K: Key + 'a, V: 'a> {
     _k: PhantomData<fn(K) -> K>,
 }
 
+impl <'a, K: 'a + Key, V: 'a> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter {
+            num_left: self.num_left,
+            slots: self.slots.clone(),
+            _k: self._k
+        }
+    }
+}
+
 /// A mutable iterator over the key-value pairs in a [`SecondaryMap`].
 ///
 /// This iterator is created by [`SecondaryMap::iter_mut`].
@@ -1338,12 +1348,28 @@ pub struct Keys<'a, K: Key + 'a, V: 'a> {
     inner: Iter<'a, K, V>,
 }
 
+impl <'a, K: 'a + Key, V: 'a> Clone for Keys<'a, K, V> {
+    fn clone(&self) -> Self {
+        Keys {
+            inner: self.inner.clone()
+        }
+    }
+}
+
 /// An iterator over the values in a [`SecondaryMap`].
 ///
 /// This iterator is created by [`SecondaryMap::values`].
 #[derive(Debug)]
 pub struct Values<'a, K: Key + 'a, V: 'a> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Values<'a, K, V> {
+    fn clone(&self) -> Self {
+        Values {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the values in a [`SecondaryMap`].

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -1312,6 +1312,15 @@ pub struct Iter<'a, K: Key + 'a, V: 'a> {
     _k: PhantomData<fn(K) -> K>,
 }
 
+impl <'a, K: 'a + Key, V: 'a> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter {
+            inner: self.inner.clone(),
+            _k: self._k
+        }
+    }
+}
+
 /// A mutable iterator over the key-value pairs in a [`SparseSecondaryMap`].
 ///
 /// This iterator is created by [`SparseSecondaryMap::iter_mut`].
@@ -1329,12 +1338,28 @@ pub struct Keys<'a, K: Key + 'a, V: 'a> {
     inner: Iter<'a, K, V>,
 }
 
+impl <'a, K: 'a + Key, V: 'a> Clone for Keys<'a, K, V> {
+    fn clone(&self) -> Self {
+        Keys {
+            inner: self.inner.clone()
+        }
+    }
+}
+
 /// An iterator over the values in a [`SparseSecondaryMap`].
 ///
 /// This iterator is created by [`SparseSecondaryMap::values`].
 #[derive(Debug)]
 pub struct Values<'a, K: Key + 'a, V: 'a> {
     inner: Iter<'a, K, V>,
+}
+
+impl <'a, K: 'a + Key, V: 'a> Clone for Values<'a, K, V> {
+    fn clone(&self) -> Self {
+        Values {
+            inner: self.inner.clone()
+        }
+    }
 }
 
 /// A mutable iterator over the values in a [`SparseSecondaryMap`].


### PR DESCRIPTION
This PR removes `#[derive(Clone)]` on iterators (`Iter`, `Values`, `Keys`) which adds unnecessary `Clone` bounds on the key and value types (due to https://github.com/rust-lang/rust/issues/26925), and replaces it with manual clone impls.

Fixes #62 