### PR TITLE
Custom Debug impl for Map types

### DIFF
--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,0 +1,17 @@
+use slotmap::SlotMap;
+
+slotmap::new_key_type! { struct CustomKey; }
+
+fn main() {
+    let mut x: SlotMap<CustomKey, &'_ str> = SlotMap::with_key();
+    let k0 = x.insert("a");
+    x.insert("b");
+    x.insert("c");
+    dbg!(&x);
+
+    x.remove(k0);
+
+    x.insert("later");
+
+    dbg!(x);
+}

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -12,6 +12,7 @@ use core::marker::PhantomData;
 #[allow(unused_imports)] // MaybeUninit is only used on nightly at the moment.
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
+use std::fmt::Debug;
 
 use crate::{DefaultKey, Key, KeyData};
 
@@ -109,12 +110,22 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 /// Slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SlotMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     free_head: u32,
     num_elems: u32,
     _k: PhantomData<fn(K) -> K>,
+}
+
+impl<K: Debug + Key, V: Debug> Debug for SlotMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_map();
+        for (k, v) in self.iter() {
+            f.entry(&k, v);
+        }
+        f.finish()
+    }
 }
 
 impl<V> SlotMap<DefaultKey, V> {

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -9,6 +9,7 @@
 #[cfg(all(nightly, any(doc, feature = "unstable")))]
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug};
 use core::iter::FusedIterator;
 #[allow(unused_imports)] // MaybeUninit is only used on nightly at the moment.
 use core::mem::MaybeUninit;
@@ -30,12 +31,22 @@ struct Slot {
 /// Dense slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DenseSlotMap<K: Key, V> {
     keys: Vec<K>,
     values: Vec<V>,
     slots: Vec<Slot>,
     free_head: u32,
+}
+
+impl<K: Debug + Key, V: Debug> Debug for DenseSlotMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_map();
+        for (k, v) in self.iter() {
+            f.entry(&k, v);
+        }
+        f.finish()
+    }
 }
 
 impl<V> DenseSlotMap<DefaultKey, V> {

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -17,7 +17,7 @@
 #[cfg(all(nightly, any(doc, feature = "unstable")))]
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
-use core::fmt;
+use core::fmt::{self, Debug};
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
@@ -129,11 +129,21 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 /// Hop slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HopSlotMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     num_elems: u32,
     _k: PhantomData<fn(K) -> K>,
+}
+
+impl<K: Debug + Key, V: Debug> Debug for HopSlotMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_map();
+        for (k, v) in self.iter() {
+            f.entry(&k, v);
+        }
+        f.finish()
+    }
 }
 
 impl<V> HopSlotMap<DefaultKey, V> {

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -6,6 +6,7 @@ use alloc::collections::TryReserveError;
 #[allow(unused_imports)] // MaybeUninit is only used on nightly at the moment.
 use core::mem::MaybeUninit;
 use std::collections::hash_map::{self, HashMap};
+use std::fmt::{self, Debug};
 use std::hash;
 use std::iter::{Extend, FromIterator, FusedIterator};
 use std::marker::PhantomData;
@@ -65,10 +66,20 @@ struct Slot<T> {
 /// ammo[alice] = 0;
 /// ```
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SparseSecondaryMap<K: Key, V, S: hash::BuildHasher = hash_map::RandomState> {
     slots: HashMap<u32, Slot<V>, S>,
     _k: PhantomData<fn(K) -> K>,
+}
+
+impl<K: Debug + Key, V: Debug, S: hash::BuildHasher> Debug for SparseSecondaryMap<K, V, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_map();
+        for (k, v) in self.iter() {
+            f.entry(&k, v);
+        }
+        f.finish()
+    }
 }
 
 impl<K: Key, V> SparseSecondaryMap<K, V, hash_map::RandomState> {


### PR DESCRIPTION
Before: 
```
[examples/debug.rs:10] &x = SlotMap {
    slots: [
        Slot {
            version: 0,
            next_free: 0,
        },
        Slot {
            version: 1,
            value: "a",
        },
        Slot {
            version: 1,
            value: "b",
        },
        Slot {
            version: 1,
            value: "c",
        },
    ],
    free_head: 4,
    num_elems: 3,
    _k: PhantomData,
}
[examples/debug.rs:16] x = SlotMap {
    slots: [
        Slot {
            version: 0,
            next_free: 0,
        },
        Slot {
            version: 3,
            value: "later",
        },
        Slot {
            version: 1,
            value: "b",
        },
        Slot {
            version: 1,
            value: "c",
        },
    ],
    free_head: 4,
    num_elems: 3,
    _k: PhantomData,
}
```


After:

```
[examples/debug.rs:10] &x = {
    CustomKey(
        1v1,
    ): "a",
    CustomKey(
        2v1,
    ): "b",
    CustomKey(
        3v1,
    ): "c",
}
[examples/debug.rs:16] x = {
    CustomKey(
        1v3,
    ): "later",
    CustomKey(
        2v1,
    ): "b",
    CustomKey(
        3v1,
    ): "c",
}
```

Fixes #65