### PR TITLE
FromIterator Implementation for SlotMap, DenseSlotMap, and HopSlotMap

### DIFF
--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1017,14 +1017,21 @@ impl<'a, K: 'a + Key, V> ExactSizeIterator for ValuesMut<'a, K, V> {}
 impl<'a, K: 'a + Key, V> ExactSizeIterator for Drain<'a, K, V> {}
 impl<K: Key, V> ExactSizeIterator for IntoIter<K, V> {}
 
-impl<K: Key, V> FromIterator<V> for DenseSlotMap<K, V> {
-    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+impl<K: Key, V> Extend<V> for DenseSlotMap<K, V> {
+    fn extend<T: IntoIterator<Item = V>>(&mut self, iter: T) {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
-        let mut map = DenseSlotMap::with_capacity_and_key(lower);
+        self.reserve(lower);
         for item in iter {
-            map.insert_with_key(|_| item);
+            self.insert_with_key(|_| item);
         }
+    }
+}
+
+impl<K: Key, V> FromIterator<V> for DenseSlotMap<K, V> {
+    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+        let mut map = DenseSlotMap::with_key();
+        map.extend(iter);
         map
     }
 }
@@ -1286,6 +1293,12 @@ mod tests {
     quickcheck! {
         fn collect(xs: Vec<u32>) -> bool {
             xs == xs.iter().cloned().collect::<DenseSlotMap<DefaultKey, u32>>().values().cloned().collect::<Vec<u32>>()
+        }
+
+        fn extend(xs: Vec<u32>) -> bool {
+            let mut map = DenseSlotMap::new();
+            map.extend(xs.clone());
+            xs == map.values().cloned().collect::<Vec<u32>>()
         }
     }
 

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -24,6 +24,7 @@ use core::mem::ManuallyDrop;
 #[allow(unused_imports)] // MaybeUninit is only used on nightly at the moment.
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
+use std::iter::FromIterator;
 
 use crate::{DefaultKey, Key, KeyData};
 
@@ -1262,6 +1263,18 @@ impl<'a, K: Key, V> ExactSizeIterator for ValuesMut<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for Drain<'a, K, V> {}
 impl<K: Key, V> ExactSizeIterator for IntoIter<K, V> {}
 
+impl<K: Key, V> FromIterator<V> for HopSlotMap<K, V> {
+    fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut map = HopSlotMap::with_capacity_and_key(lower);
+        for item in iter {
+            map.insert_with_key(|_| item);
+        }
+        map
+    }
+}
+
 // Serialization with serde.
 #[cfg(feature = "serde")]
 mod serialize {
@@ -1551,6 +1564,12 @@ mod tests {
             smv.sort();
             hmv.sort();
             smv == hmv
+        }
+    }
+
+    quickcheck! {
+        fn collect(xs: Vec<u32>) -> bool {
+            xs == xs.iter().cloned().collect::<HopSlotMap<DefaultKey, u32>>().values().cloned().collect::<Vec<u32>>()
         }
     }
 


### PR DESCRIPTION
I was missing a `FromIterator` implementation for `SlotMap` to be able to do

```
let _map1 = SlotMap::<DefaultKey, i32>::from_iter([1, 2, 3]);
```

and

```
let _map2 = vec![1, 2, 3].into_iter().collect::<SlotMap<DefaultKey, i32>>();
```

I added implementations for `DenseSlotMap` and `HopSlotMap` as well and a `quickcheck` test for each implementation.

Please let me know if the implementation is not what you expect or it clashes with your vision of `slotmap`.