### PR TITLE
Add try_insert_with_key that accepts a fallible closure

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -350,6 +350,36 @@ impl<K: Key, V> SlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
+        self.try_insert_with_key::<_, ()>(move |k| Ok(f(k)))
+            .ok()
+            .unwrap()
+    }
+
+    /// Inserts a value given by `f` into the slot map. The key where the
+    /// value will be stored is passed into `f`. This is useful to store values
+    /// that contain their own key.
+    ///
+    /// If `f` returns `Err`, this method returns the error. The slotmap is untouched.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the slot map equals
+    /// 2<sup>32</sup> - 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = SlotMap::new();
+    /// let key = sm.try_insert_with_key::<_, ()>(|k| Ok((k, 20))).unwrap();
+    /// assert_eq!(sm[key], (key, 20));
+    ///
+    /// sm.try_insert_with_key::<_, ()>(|k| Err(())).unwrap_err();
+    /// ```
+    pub fn try_insert_with_key<F, E>(&mut self, f: F) -> Result<K, E>
+    where
+        F: FnOnce(K) -> Result<V, E>,
+    {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
         if new_num_elems == core::u32::MAX {
@@ -360,8 +390,8 @@ impl<K: Key, V> SlotMap<K, V> {
             let occupied_version = slot.version | 1;
             let kd = KeyData::new(self.free_head, occupied_version);
 
-            // Get value first in case f panics.
-            let value = f(kd.into());
+            // Get value first in case f panics or returns an error.
+            let value = f(kd.into())?;
 
             // Update.
             unsafe {
@@ -370,7 +400,7 @@ impl<K: Key, V> SlotMap<K, V> {
                 slot.version = occupied_version;
             }
             self.num_elems = new_num_elems;
-            return kd.into();
+            return Ok(kd.into());
         }
 
         let version = 1;
@@ -379,14 +409,14 @@ impl<K: Key, V> SlotMap<K, V> {
         // Create new slot before adjusting freelist in case f or the allocation panics.
         self.slots.push(Slot {
             u: SlotUnion {
-                value: ManuallyDrop::new(f(kd.into())),
+                value: ManuallyDrop::new(f(kd.into())?),
             },
             version,
         });
 
         self.free_head = kd.idx + 1;
         self.num_elems = new_num_elems;
-        kd.into()
+        Ok(kd.into())
     }
 
     // Helper function to remove a value from a slot. Safe iff the slot is

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -274,6 +274,36 @@ impl<K: Key, V> DenseSlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
+        self.try_insert_with_key::<_, ()>(move |k| Ok(f(k)))
+            .ok()
+            .unwrap()
+    }
+
+    /// Inserts a value given by `f` into the slot map. The key where the
+    /// value will be stored is passed into `f`. This is useful to store values
+    /// that contain their own key.
+    ///
+    /// If `f` returns `Err`, this method returns the error. The slotmap is untouched.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the slot map equals
+    /// 2<sup>32</sup> - 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = DenseSlotMap::new();
+    /// let key = sm.try_insert_with_key::<_, ()>(|k| Ok((k, 20))).unwrap();
+    /// assert_eq!(sm[key], (key, 20));
+    ///
+    /// sm.try_insert_with_key::<_, ()>(|k| Err(())).unwrap_err();
+    /// ```
+    pub fn try_insert_with_key<F, E>(&mut self, f: F) -> Result<K, E>
+    where
+        F: FnOnce(K) -> Result<V, E>,
+    {
         if self.len() >= (core::u32::MAX - 1) as usize {
             panic!("DenseSlotMap number of elements overflow");
         }
@@ -284,25 +314,25 @@ impl<K: Key, V> DenseSlotMap<K, V> {
             let occupied_version = slot.version | 1;
             let key = KeyData::new(idx, occupied_version).into();
 
-            // Push value before adjusting slots/freelist in case f panics.
-            self.values.push(f(key));
+            // Push value before adjusting slots/freelist in case f panics or returns an error.
+            self.values.push(f(key)?);
             self.keys.push(key);
             self.free_head = slot.idx_or_free;
             slot.idx_or_free = self.keys.len() as u32 - 1;
             slot.version = occupied_version;
-            return key;
+            return Ok(key);
         }
 
-        // Push value before adjusting slots/freelist in case f panics.
+        // Push value before adjusting slots/freelist in case f panics or returns an error.
         let key = KeyData::new(idx, 1).into();
-        self.values.push(f(key));
+        self.values.push(f(key)?);
         self.keys.push(key);
         self.slots.push(Slot {
             version: 1,
             idx_or_free: self.keys.len() as u32 - 1,
         });
         self.free_head = self.slots.len() as u32;
-        key
+        Ok(key)
     }
 
     // Helper function to add a slot to the freelist. Returns the index that

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -362,6 +362,36 @@ impl<K: Key, V> HopSlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
+        self.try_insert_with_key::<_, ()>(move |k| Ok(f(k)))
+            .ok()
+            .unwrap()
+    }
+
+    /// Inserts a value given by `f` into the slot map. The key where the
+    /// value will be stored is passed into `f`. This is useful to store values
+    /// that contain their own key.
+    ///
+    /// If `f` returns `Err`, this method returns the error. The slotmap is untouched.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of elements in the slot map equals
+    /// 2<sup>32</sup> - 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = HopSlotMap::new();
+    /// let key = sm.try_insert_with_key::<_, ()>(|k| Ok((k, 20))).unwrap();
+    /// assert_eq!(sm[key], (key, 20));
+    ///
+    /// sm.try_insert_with_key::<_, ()>(|k| Err(())).unwrap_err();
+    /// ```
+    pub fn try_insert_with_key<F, E>(&mut self, f: F) -> Result<K, E>
+    where
+        F: FnOnce(K) -> Result<V, E>,
+    {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
         if new_num_elems == core::u32::MAX {
@@ -386,18 +416,18 @@ impl<K: Key, V> HopSlotMap<K, V> {
 
                 self.slots.push(Slot {
                     u: SlotUnion {
-                        value: ManuallyDrop::new(f(key)),
+                        value: ManuallyDrop::new(f(key)?),
                     },
                     version,
                 });
                 self.num_elems = new_num_elems;
-                return key;
+                return Ok(key);
             }
 
-            // Compute value first in case f panics.
+            // Compute value first in case f panics or returns an error.
             let occupied_version = self.slots[slot_idx].version | 1;
             let key = KeyData::new(slot_idx as u32, occupied_version).into();
-            let value = f(key);
+            let value = f(key)?;
 
             // Update freelist.
             if front == back {
@@ -417,7 +447,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
             slot.version = occupied_version;
             slot.u.value = ManuallyDrop::new(value);
             self.num_elems = new_num_elems;
-            key
+            Ok(key)
         }
     }
 


### PR DESCRIPTION
Adds a new `try_insert_with_key` method to `SlotMap`, `DenseSlotMap`, and `HopSlotMap`. This method accepts a closure returning a `Result`. If the closure returns an error, `try_insert_with_key` leaves the slotmap untouched and returns the error.

This is useful when value construction is fallible.