### PR TITLE
Bump quickcheck to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fxhash = "0.2.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-quickcheck = "0.9"
+quickcheck = "1.0"
 
 [build-dependencies]
 version_check = "0.9"


### PR DESCRIPTION
Since there is a 1.0 release, it seems reasonable to build against that.
This will also reduce the delta we need for the Debian package, which
currently patches the dependency.