### PR TITLE
Const version of `Key::null()`

### DIFF
--- a/examples/doubly_linked_list.rs
+++ b/examples/doubly_linked_list.rs
@@ -121,7 +121,7 @@ fn main() {
     dll.push_tail(7);
     dll.push_head(4);
 
-    assert_eq!(dll.len(), 4);
+    assert_eq!(dll.len(), 5);
     assert_eq!(dll.pop_head(), Some(4));
     assert_eq!(dll.pop_head(), Some(5));
     assert_eq!(dll.head(), k);

--- a/examples/doubly_linked_list.rs
+++ b/examples/doubly_linked_list.rs
@@ -23,8 +23,8 @@ impl<T> List<T> {
     pub fn new() -> Self {
         Self {
             sm: SlotMap::with_key(),
-            head: ListKey::null(),
-            tail: ListKey::null(),
+            head: ListKey::NULL,
+            tail: ListKey::NULL,
         }
     }
 
@@ -35,7 +35,7 @@ impl<T> List<T> {
     pub fn push_head(&mut self, value: T) -> ListKey {
         let k = self.sm.insert(Node {
             value,
-            prev: ListKey::null(),
+            prev: ListKey::NULL,
             next: self.head,
         });
 
@@ -52,7 +52,7 @@ impl<T> List<T> {
         let k = self.sm.insert(Node {
             value,
             prev: self.tail,
-            next: ListKey::null(),
+            next: ListKey::NULL,
         });
 
         if let Some(old_tail) = self.sm.get_mut(self.tail) {

--- a/examples/rand_meld_heap.rs
+++ b/examples/rand_meld_heap.rs
@@ -28,7 +28,7 @@ impl<T: Ord + std::fmt::Debug> RandMeldHeap<T> {
         Self {
             sm: SlotMap::with_key(),
             rng: std::num::Wrapping(0xdead_beef),
-            root: HeapKey::null(),
+            root: HeapKey::NULL,
         }
     }
 
@@ -41,8 +41,8 @@ impl<T: Ord + std::fmt::Debug> RandMeldHeap<T> {
     pub fn insert(&mut self, value: T) -> NodeHandle {
         let k = self.sm.insert(Node {
             value,
-            children: [HeapKey::null(), HeapKey::null()],
-            parent: HeapKey::null(),
+            children: [HeapKey::NULL, HeapKey::NULL],
+            parent: HeapKey::NULL,
         });
 
         let root = self.root;
@@ -55,7 +55,7 @@ impl<T: Ord + std::fmt::Debug> RandMeldHeap<T> {
         self.sm.remove(self.root).map(|root| {
             self.root = self.meld(root.children[0], root.children[1]);
             if let Some(new_root) = self.sm.get_mut(self.root) {
-                new_root.parent = HeapKey::null();
+                new_root.parent = HeapKey::NULL;
             }
 
             root.value
@@ -75,8 +75,8 @@ impl<T: Ord + std::fmt::Debug> RandMeldHeap<T> {
         self.unlink_node(node);
         self.sm[node] = Node {
             value,
-            children: [HeapKey::null(), HeapKey::null()],
-            parent: HeapKey::null(),
+            children: [HeapKey::NULL, HeapKey::NULL],
+            parent: HeapKey::NULL,
         };
         let root = self.root;
         self.root = self.meld(node, root);


### PR DESCRIPTION
* Deprecated `KeyData::null()` and `Key::null()`.
* Made `KeyData::new()` const
* Added `KeyData::NULL` and `Key::NULL` and `$k::NULL` for the macro key impl.
* Fixed assert in example