### PR TITLE
Detect wrongly interchanged keys during runtime 

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -13,6 +13,9 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
 
+#[cfg(debug_assertions)]
+use core::panic::Location;
+
 use crate::util::{Never, UnwrapUnchecked};
 use crate::{DefaultKey, Key, KeyData};
 
@@ -132,6 +135,8 @@ pub struct SlotMap<K: Key, V> {
     free_head: u32,
     num_elems: u32,
     _k: PhantomData<fn(K) -> K>,
+    #[cfg(debug_assertions)]
+    unique_location: &'static Location<'static>
 }
 
 impl<V> SlotMap<DefaultKey, V> {
@@ -143,6 +148,7 @@ impl<V> SlotMap<DefaultKey, V> {
     /// # use slotmap::*;
     /// let mut sm: SlotMap<_, i32> = SlotMap::new();
     /// ```
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn new() -> Self {
         Self::with_capacity_and_key(0)
     }
@@ -158,6 +164,7 @@ impl<V> SlotMap<DefaultKey, V> {
     /// # use slotmap::*;
     /// let mut sm: SlotMap<_, i32> = SlotMap::with_capacity(10);
     /// ```
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn with_capacity(capacity: usize) -> Self {
         Self::with_capacity_and_key(capacity)
     }
@@ -175,6 +182,7 @@ impl<K: Key, V> SlotMap<K, V> {
     /// }
     /// let mut positions: SlotMap<PositionKey, i32> = SlotMap::with_key();
     /// ```
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn with_key() -> Self {
         Self::with_capacity_and_key(0)
     }
@@ -197,6 +205,7 @@ impl<K: Key, V> SlotMap<K, V> {
     /// let good_day = messages.insert("Good day");
     /// let hello = messages.insert("Hello");
     /// ```
+    #[cfg_attr(debug_assertions, track_caller)]
     pub fn with_capacity_and_key(capacity: usize) -> Self {
         // Create slots with a sentinel at index 0.
         // We don't actually use the sentinel for anything currently, but
@@ -213,6 +222,8 @@ impl<K: Key, V> SlotMap<K, V> {
             free_head: 1,
             num_elems: 0,
             _k: PhantomData,
+            #[cfg(debug_assertions)]
+            unique_location: Location::caller()
         }
     }
 
@@ -417,7 +428,7 @@ impl<K: Key, V> SlotMap<K, V> {
                 slot.version = occupied_version;
             }
             self.num_elems = new_num_elems;
-            return Ok(kd.into());
+            return Ok(crate::new_key!(kd, self));
         }
 
         let version = 1;
@@ -426,14 +437,15 @@ impl<K: Key, V> SlotMap<K, V> {
         // Create new slot before adjusting freelist in case f or the allocation panics or errors.
         self.slots.push(Slot {
             u: SlotUnion {
-                value: ManuallyDrop::new(f(kd.into())?),
+                value: ManuallyDrop::new(f(crate::new_key!(kd, self))?),
             },
             version,
         });
 
         self.free_head = kd.idx + 1;
         self.num_elems = new_num_elems;
-        Ok(kd.into())
+
+        Ok(crate::new_key!(kd, self))
     }
 
     // Helper function to remove a value from a slot. Safe iff the slot is
@@ -583,6 +595,9 @@ impl<K: Key, V> SlotMap<K, V> {
     /// assert_eq!(sm.get(key), None);
     /// ```
     pub fn get(&self, key: K) -> Option<&V> {
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(key.location(), self.unique_location, "A key created by a specific SlotMap is used for another SlotMap.");
+
         let kd = key.data();
         self.slots
             .get(kd.idx as usize)
@@ -1537,5 +1552,82 @@ mod tests {
         de.insert(1);
         de.insert(2);
         assert_eq!(de.len(), 3);
+    }
+
+    #[cfg(debug_assertions)]
+    pub struct Map<K: Key, V> {
+        slot_map: SlotMap<K, V>
+    }
+
+    #[cfg(debug_assertions)]
+    impl<V> Map<DefaultKey, V> {
+        fn new() -> Self {
+            Map {
+                slot_map: SlotMap::new()
+            }
+        }
+
+        #[track_caller]
+        fn new_tracked() -> Self {
+            Map {
+                slot_map: SlotMap::new()
+            }
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn wrapped_slotmap_type_untracked_key_exchange() {
+        let mut map1 = Map::new();
+        let k1 = map1.slot_map.insert(4);
+        
+        let mut map2 = Map::new();
+        
+        map2.slot_map.insert(4);
+
+        map2.slot_map.get(k1).unwrap();
+    }
+
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    #[test]
+    fn wrapped_slotmap_type_tracked_key_exchange() {
+        let mut map1 = Map::new_tracked();
+        let k1 = map1.slot_map.insert(4);
+        
+        let mut map2 = Map::new_tracked();
+        
+        map2.slot_map.insert(4);
+
+        map2.slot_map.get(k1);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn slotmap_key_own_map() {
+        let mut sm1 = SlotMap::new();
+
+        let k1 = sm1.insert(5);
+
+
+        let mut sm2 = SlotMap::new();
+        sm2.insert(3);
+
+        sm1.get(k1).unwrap();
+    }
+
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    #[test]
+    fn slotmap_key_exchange() {
+        let mut sm1 = SlotMap::new();
+
+        let k1 = sm1.insert(5);
+
+
+        let mut sm2 = SlotMap::new();
+        sm2.insert(3);
+
+        sm2.get(k1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,20 +471,35 @@ macro_rules! new_key_type {
         $vis struct $name($crate::KeyData);
 
         #[derive(Copy, Clone, Default,
-            Eq, PartialEq, Ord, PartialOrd,
-            Hash, Debug)]
+            Eq, Ord, PartialOrd, Debug)]
         #[cfg(debug_assertions)]
         $(#[$outer])*
         $vis struct $name {
             key_data: $crate::KeyData,
             location: Option<&'static core::panic::Location<'static>>
+        }        
+
+        #[cfg(debug_assertions)]
+        impl PartialEq for $name {
+            #[inline]
+            fn eq(&self, other: &$name) -> bool {
+                self.key_data == other.key_data
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        impl core::hash::Hash for $name {
+            #[inline]
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                self.key_data.hash(state);
+            }
         }
 
         impl $crate::__impl::From<$crate::KeyData> for $name {
             fn from(k: $crate::KeyData) -> Self {
                 $name {
                     key_data: k,
-                    location: Some(core::panic::Location::caller())
+                    location: None
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,16 @@ pub unsafe trait Key:
     /// assert_eq!(dk.data(), mk.data());
     /// ```
     fn data(&self) -> KeyData;
+
+    #[cfg(debug_assertions)]
+    /// Sets the location in the source code of a used slot map.
+    fn set_location(&mut self, location: &'static core::panic::Location<'static>);
+
+    #[cfg(debug_assertions)]
+    /// Returns the location in the source code of a used slot map.
+    fn location(&self) -> &'static core::panic::Location<'static>;
 }
+
 
 /// A helper macro to create new key types. If you use a new key type for each
 /// slot map you create you can entirely prevent using the wrong key on the
@@ -456,20 +465,47 @@ macro_rules! new_key_type {
         #[derive(Copy, Clone, Default,
                  Eq, PartialEq, Ord, PartialOrd,
                  Hash, Debug)]
+
+        #[cfg(not(debug_assertions))]
         #[repr(transparent)]
         $vis struct $name($crate::KeyData);
 
+        #[derive(Copy, Clone, Default,
+            Eq, PartialEq, Ord, PartialOrd,
+            Hash, Debug)]
+        #[cfg(debug_assertions)]
+        $(#[$outer])*
+        $vis struct $name {
+            key_data: $crate::KeyData,
+            location: Option<&'static core::panic::Location<'static>>
+        }
+
         impl $crate::__impl::From<$crate::KeyData> for $name {
             fn from(k: $crate::KeyData) -> Self {
-                $name(k)
+                $name {
+                    key_data: k,
+                    location: Some(core::panic::Location::caller())
+                }
             }
         }
 
         unsafe impl $crate::Key for $name {
             fn data(&self) -> $crate::KeyData {
-                self.0
+                self.key_data
+            }
+            
+            #[cfg(debug_assertions)]
+            #[inline]
+            fn set_location(&mut self, location: &'static core::panic::Location<'static>) {
+                self.location = Some(location);
+            }
+            #[cfg(debug_assertions)]
+            #[inline]
+            fn location(&self) -> &'static core::panic::Location<'static> {
+                self.location.expect("Should be set during key instantiation while in debug mode")
             }
         }
+
 
         $crate::__serialize_key!($name);
 
@@ -516,6 +552,26 @@ macro_rules! __serialize_key {
 new_key_type! {
     /// The default slot map key type.
     pub struct DefaultKey;
+}
+
+#[macro_export]
+/// TODO
+macro_rules! new_key {
+    ($kd:ident, $self:ident) => {
+        {
+            let mut key: K;
+            #[cfg(debug_assertions)]
+            {
+                key = $kd.into();
+                key.set_location($self.unique_location)
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                key = kd.into()
+            }  
+            key
+        }
+    };
 }
 
 // Serialization with serde.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,16 +497,30 @@ macro_rules! new_key_type {
 
         impl $crate::__impl::From<$crate::KeyData> for $name {
             fn from(k: $crate::KeyData) -> Self {
-                $name {
-                    key_data: k,
-                    location: None
+                #[cfg(debug_assertions)]
+                {
+                    $name {
+                        key_data: k,
+                        location: None
+                    }
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    $name(k)
                 }
             }
         }
 
         unsafe impl $crate::Key for $name {
             fn data(&self) -> $crate::KeyData {
-                self.key_data
+                #[cfg(debug_assertions)]    
+                {
+                    self.key_data
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    self.0
+                }
             }
             
             #[cfg(debug_assertions)]
@@ -574,17 +588,18 @@ new_key_type! {
 macro_rules! new_key {
     ($kd:ident, $self:ident) => {
         {
-            let mut key: K;
+            
             #[cfg(debug_assertions)]
             {
-                key = $kd.into();
-                key.set_location($self.unique_location)
+                let mut key: K = $kd.into();
+                key.set_location($self.unique_location);
+                key
             }
             #[cfg(not(debug_assertions))]
             {
-                key = kd.into()
+                Into::<K>::into($kd)
             }  
-            key
+            
         }
     };
 }


### PR DESCRIPTION
This pull request refers to the following statement located in the docs:

> If you have multiple slot maps it’s an error to use the key of one slot map on another slot map. The result is safe, but unspecified, and can not be detected at runtime, so it can lead to a hard to find bug.

However, there may be a way to detect such occurrences during runtime, though.
It utilises the `core::panic::Location` and `#[track_caller]` to match a `SlotMap` with a `DefaultKey`. This mechanic is used in `RefCell` as well. 

I implemented a proof-of-concept for `SlotMap` only and would like to here your opinion about this idea.  