### PR TITLE
Improve efficiency of `occupied`

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -47,7 +47,7 @@ impl<T> Slot<T> {
     // Is this slot occupied?
     #[inline(always)]
     pub fn occupied(&self) -> bool {
-        self.version % 2 > 0
+        self.version & 1 != 0
     }
 
     pub fn get(&self) -> SlotContent<T> {


### PR DESCRIPTION
Previously `occupied` checke if version was odd by self.version % 2 > 0 However this requires a costly modulos when we instead can use a bitwise and and check whether the LSB is 0 or 1.