### PR TITLE
Add UnwrapNever helper to remove some unsafe.

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, PanicOnDrop};
+use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
 
 // Storage inside a slot or metadata for the freelist when vacant.
@@ -341,10 +341,8 @@ impl<K: Key, V> SlotMap<K, V> {
     /// ```
     #[inline(always)]
     pub fn insert(&mut self, value: V) -> K {
-        unsafe {
-            self.try_insert_with_key::<_, Never>(move |_| Ok(value))
-                .unwrap_unchecked()
-        }
+        self.try_insert_with_key::<_, Never>(move |_| Ok(value))
+            .unwrap_never()
     }
 
     /// Inserts a value given by `f` into the slot map. The key where the
@@ -369,10 +367,8 @@ impl<K: Key, V> SlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
-        unsafe {
-            self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
-                .unwrap_unchecked()
-        }
+        self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
+            .unwrap_never()
     }
 
     /// Inserts a value given by `f` into the slot map. The key where the

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -12,7 +12,7 @@ use core::iter::FusedIterator;
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, PanicOnDrop};
+use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
 
 // A slot, which represents storage for an index and a current version.
@@ -248,10 +248,8 @@ impl<K: Key, V> DenseSlotMap<K, V> {
     /// ```
     #[inline(always)]
     pub fn insert(&mut self, value: V) -> K {
-        unsafe {
-            self.try_insert_with_key::<_, Never>(move |_| Ok(value))
-                .unwrap_unchecked()
-        }
+        self.try_insert_with_key::<_, Never>(move |_| Ok(value))
+            .unwrap_never()
     }
 
     /// Inserts a value given by `f` into the slot map. The key where the
@@ -276,10 +274,8 @@ impl<K: Key, V> DenseSlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
-        unsafe {
-            self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
-                .unwrap_unchecked()
-        }
+        self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
+            .unwrap_never()
     }
 
     /// Inserts a value given by `f` into the slot map. The key where the

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -19,7 +19,7 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, PanicOnDrop};
+use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
 
 // Metadata to maintain the freelist.
@@ -359,10 +359,8 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// ```
     #[inline(always)]
     pub fn insert(&mut self, value: V) -> K {
-        unsafe {
-            self.try_insert_with_key::<_, Never>(move |_| Ok(value))
-                .unwrap_unchecked()
-        }
+        self.try_insert_with_key::<_, Never>(move |_| Ok(value))
+            .unwrap_never()
     }
 
     // Helper function to make using the freelist painless.
@@ -394,10 +392,8 @@ impl<K: Key, V> HopSlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
-        unsafe {
-            self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
-                .unwrap_unchecked()
-        }
+        self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
+            .unwrap_never()
     }
 
     /// Inserts a value given by `f` into the slot map. The key where the

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,20 @@ use core::fmt::Debug;
 #[derive(Debug)]
 pub enum Never {}
 
+pub trait UnwrapNever<T> {
+    fn unwrap_never(self) -> T;
+}
+
+impl<T> UnwrapNever<T> for Result<T, Never> {
+    #[inline(always)]
+    fn unwrap_never(self) -> T {
+        match self {
+            Ok(x) => x,
+            Err(e) => match e {},
+        }
+    }
+}
+
 /// Returns if a is an older version than b, taking into account wrapping of
 /// versions.
 pub fn is_older_version(a: u32, b: u32) -> bool {


### PR DESCRIPTION
`Result<T, Never>` can be matched to produce an infallible and safe unwrap function.