### PR TITLE
Make KeyData::from_ffi const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub struct KeyData {
 }
 
 impl KeyData {
-    fn new(idx: u32, version: u32) -> Self {
+    const fn new(idx: u32, version: u32) -> Self {
         debug_assert!(version > 0);
 
         Self {
@@ -300,7 +300,7 @@ impl KeyData {
 
     /// Iff `value` is a value received from `k.as_ffi()`, returns a key equal
     /// to `k`. Otherwise the behavior is safe but unspecified.
-    pub fn from_ffi(value: u64) -> Self {
+    pub const fn from_ffi(value: u64) -> Self {
         let idx = value & 0xffff_ffff;
         let version = (value >> 32) | 1; // Ensure version is odd.
         Self::new(idx as u32, version as u32)


### PR DESCRIPTION
This change updates `KeyData::from_ffi` to be const. 

Although the common use case is for keys to be created only when inserting into a `SlotMap`, creating a key independent of a map can be useful for testing. Having a way to construct `KeyData` in a const context makes it more convenient to setup these fake keys for tests.

Related to #85