### PR TITLE
Implement Debug semantically instead of structurally

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -13,7 +13,7 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, UnwrapUnchecked};
+use crate::util::{Never, UnwrapUnchecked, debug_fmt_entries};
 use crate::{DefaultKey, Key, KeyData};
 
 // Storage inside a slot or metadata for the freelist when vacant.
@@ -126,7 +126,6 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 /// Slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug)]
 pub struct SlotMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     free_head: u32,
@@ -935,6 +934,12 @@ impl<K: Key, V> IndexMut<K> for SlotMap<K, V> {
             Some(r) => r,
             None => panic!("invalid SlotMap key used"),
         }
+    }
+}
+
+impl<K: Key, V: fmt::Debug> fmt::Debug for SlotMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        debug_fmt_entries(self, f)
     }
 }
 

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -9,12 +9,13 @@
 #[cfg(all(nightly, any(doc, feature = "unstable")))]
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
+use core::fmt;
 use core::iter::FusedIterator;
 #[allow(unused_imports)] // MaybeUninit is only used on nightly at the moment.
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, UnwrapUnchecked};
+use crate::util::{Never, UnwrapUnchecked, debug_fmt_entries};
 use crate::{DefaultKey, Key, KeyData};
 
 // A slot, which represents storage for an index and a current version.
@@ -31,7 +32,6 @@ struct Slot {
 /// Dense slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug)]
 pub struct DenseSlotMap<K: Key, V> {
     keys: Vec<K>,
     values: Vec<V>,
@@ -831,6 +831,12 @@ impl<K: Key, V> IndexMut<K> for DenseSlotMap<K, V> {
             Some(r) => r,
             None => panic!("invalid DenseSlotMap key used"),
         }
+    }
+}
+
+impl<K: Key, V: fmt::Debug> fmt::Debug for DenseSlotMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        debug_fmt_entries(self, f)
     }
 }
 

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -25,7 +25,7 @@ use core::mem::ManuallyDrop;
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, UnwrapUnchecked};
+use crate::util::{Never, UnwrapUnchecked, debug_fmt_entries};
 use crate::{DefaultKey, Key, KeyData};
 
 // Metadata to maintain the freelist.
@@ -144,7 +144,6 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 /// Hop slot map, storage with stable unique keys.
 ///
 /// See [crate documentation](crate) for more details.
-#[derive(Debug)]
 pub struct HopSlotMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     num_elems: u32,
@@ -1021,6 +1020,12 @@ impl<K: Key, V> IndexMut<K> for HopSlotMap<K, V> {
             Some(r) => r,
             None => panic!("invalid HopSlotMap key used"),
         }
+    }
+}
+
+impl<K: Key, V: fmt::Debug> fmt::Debug for HopSlotMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        debug_fmt_entries(self, f)
     }
 }
 

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -3,6 +3,7 @@
 #[cfg(all(nightly, any(doc, feature = "unstable")))]
 use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
+use core::fmt;
 use core::hint::unreachable_unchecked;
 use core::iter::{Enumerate, Extend, FromIterator, FusedIterator};
 use core::marker::PhantomData;
@@ -13,7 +14,7 @@ use core::num::NonZeroU32;
 use core::ops::{Index, IndexMut};
 
 use super::{Key, KeyData};
-use crate::util::is_older_version;
+use crate::util::{debug_fmt_entries, is_older_version};
 
 // This representation works because we don't have to store the versions
 // of removed elements.
@@ -118,7 +119,7 @@ impl<T> Slot<T> {
 /// health[bob] -= ammo[alice] * 3;
 /// ammo[alice] = 0;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SecondaryMap<K: Key, V> {
     slots: Vec<Slot<V>>,
     num_elems: usize,
@@ -913,6 +914,12 @@ impl<'a, K: Key, V: 'a + Copy> Extend<(K, &'a V)> for SecondaryMap<K, V> {
         for (k, v) in iter {
             self.insert(k, *v);
         }
+    }
+}
+
+impl<K: Key, V: fmt::Debug> fmt::Debug for SecondaryMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        debug_fmt_entries(self, f)
     }
 }
 

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -5,13 +5,14 @@ use alloc::collections::TryReserveError;
 #[allow(unused_imports)] // MaybeUninit is only used on nightly at the moment.
 use core::mem::MaybeUninit;
 use std::collections::hash_map::{self, HashMap};
+use std::fmt;
 use std::hash;
 use std::iter::{Extend, FromIterator, FusedIterator};
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 
 use super::{Key, KeyData};
-use crate::util::{is_older_version, UnwrapUnchecked};
+use crate::util::{debug_fmt_entries, is_older_version, UnwrapUnchecked};
 
 #[derive(Debug, Clone)]
 struct Slot<T> {
@@ -67,7 +68,7 @@ struct Slot<T> {
 /// ammo[alice] = 0;
 /// ```
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SparseSecondaryMap<K: Key, V, S: hash::BuildHasher = hash_map::RandomState> {
     slots: HashMap<u32, Slot<V>, S>,
     _k: PhantomData<fn(K) -> K>,
@@ -909,6 +910,17 @@ where
         for (k, v) in iter {
             self.insert(k, *v);
         }
+    }
+}
+
+impl<K, V, S> fmt::Debug for SparseSecondaryMap<K, V, S>
+where
+    K: Key,
+    V: fmt::Debug,
+    S: hash::BuildHasher
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        debug_fmt_entries(self, f)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
-use core::fmt::Debug;
+use crate::Key;
+use core::fmt;
 use core::hint::unreachable_unchecked;
 
 /// Internal stable replacement for !.
@@ -32,7 +33,7 @@ impl<T> UnwrapUnchecked<T> for Option<T> {
     }
 }
 
-impl<T, E: Debug> UnwrapUnchecked<T> for Result<T, E> {
+impl<T, E: fmt::Debug> UnwrapUnchecked<T> for Result<T, E> {
     unsafe fn unwrap_unchecked_(self) -> T {
         if cfg!(debug_assertions) {
             self.unwrap()
@@ -43,4 +44,17 @@ impl<T, E: Debug> UnwrapUnchecked<T> for Result<T, E> {
             }
         }
     }
+}
+
+/// Debug format a slot map.
+/// Keys are formatted without the name of the wrapper struct
+/// (`1v2` instead of `MyKey(1v2)`).
+pub fn debug_fmt_entries<I, K, V>(entries: I, f: &mut fmt::Formatter) -> fmt::Result
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Key,
+    V: fmt::Debug
+{
+    let entries = entries.into_iter().map(|(k, v)| (k.data(), v));
+    f.debug_map().entries(entries).finish()
 }


### PR DESCRIPTION
Slot maps are now debug formatted with Formatter::debug_map, hiding the internal structure of the slot map.