### PR TITLE
Code cleanup.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/orlp/slotmap"
 readme = "README.md"
 keywords = ["slotmap", "storage", "allocator", "arena", "reference"]
 categories = ["data-structures", "memory-management", "caching"]
+rust-version = "1.58.0"
 
 [features]
 default = ["std"]

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,14 @@
 fn main() {
     let is_nightly = version_check::is_feature_flaggable() == Some(true);
-    let is_at_least_1_49 = version_check::is_min_version("1.49.0").unwrap_or(false);
-    let is_at_least_1_51 = version_check::is_min_version("1.51.0").unwrap_or(false);
+    let is_at_least_1_58 = version_check::is_min_version("1.58.0").unwrap_or(false);
+    let is_at_least_1_80 = version_check::is_min_version("1.80.0").unwrap_or(false);
 
-    if !is_at_least_1_49 {
-        println!("cargo:warning=slotmap requires rustc => 1.49.0");
+    if !is_at_least_1_58 {
+        println!("cargo:warning=slotmap requires rustc => 1.58.0");
     }
 
-    if is_at_least_1_51 || is_nightly {
-        println!("cargo:rustc-cfg=has_min_const_generics");
+    if is_at_least_1_80 || is_nightly {
+        println!("cargo:rustc-check-cfg=cfg(nightly)");
     }
 
     if is_nightly {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+match_block_trailing_comma = true

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -25,7 +25,7 @@ use core::mem::ManuallyDrop;
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
-use crate::util::{Never, PanicOnDrop, UnwrapUnchecked};
+use crate::util::{Never, PanicOnDrop};
 use crate::{DefaultKey, Key, KeyData};
 
 // Metadata to maintain the freelist.
@@ -70,7 +70,7 @@ impl<T> Slot<T> {
         self.version % 2 == 1
     }
 
-    pub fn get(&self) -> SlotContent<T> {
+    pub fn get(&self) -> SlotContent<'_, T> {
         unsafe {
             if self.occupied() {
                 Occupied(&*self.u.value)
@@ -80,7 +80,7 @@ impl<T> Slot<T> {
         }
     }
 
-    pub fn get_mut(&mut self) -> SlotContentMut<T> {
+    pub fn get_mut(&mut self) -> SlotContentMut<'_, T> {
         unsafe {
             if self.occupied() {
                 OccupiedMut(&mut *self.u.value)
@@ -367,7 +367,10 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// ```
     #[inline(always)]
     pub fn insert(&mut self, value: V) -> K {
-        unsafe { self.try_insert_with_key::<_, Never>(move |_| Ok(value)).unwrap_unchecked_() }
+        unsafe {
+            self.try_insert_with_key::<_, Never>(move |_| Ok(value))
+                .unwrap_unchecked()
+        }
     }
 
     // Helper function to make using the freelist painless.
@@ -399,7 +402,10 @@ impl<K: Key, V> HopSlotMap<K, V> {
     where
         F: FnOnce(K) -> V,
     {
-        unsafe { self.try_insert_with_key::<_, Never>(move |k| Ok(f(k))).unwrap_unchecked_() }
+        unsafe {
+            self.try_insert_with_key::<_, Never>(move |k| Ok(f(k)))
+                .unwrap_unchecked()
+        }
     }
 
     /// Inserts a value given by `f` into the slot map. The key where the
@@ -429,7 +435,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     {
         // In case f panics, we don't make any changes until we have the value.
         let new_num_elems = self.num_elems + 1;
-        if new_num_elems == core::u32::MAX {
+        if new_num_elems == u32::MAX {
             panic!("HopSlotMap number of elements overflow");
         }
 
@@ -666,7 +672,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// assert_eq!(sm.len(), 0);
     /// assert_eq!(v, vec![(k, 0)]);
     /// ```
-    pub fn drain(&mut self) -> Drain<K, V> {
+    pub fn drain(&mut self) -> Drain<'_, K, V> {
         Drain {
             cur: unsafe { self.slots.get_unchecked(0).u.free.other_end as usize + 1 },
             sm: self,
@@ -762,7 +768,11 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// ```
     pub unsafe fn get_unchecked_mut(&mut self, key: K) -> &mut V {
         debug_assert!(self.contains_key(key));
-        &mut self.slots.get_unchecked_mut(key.data().idx as usize).u.value
+        &mut self
+            .slots
+            .get_unchecked_mut(key.data().idx as usize)
+            .u
+            .value
     }
 
     /// Returns mutable references to the values corresponding to the given
@@ -787,7 +797,6 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// assert_eq!(sm[ka], "apples");
     /// assert_eq!(sm[kb], "butter");
     /// ```
-    #[cfg(has_min_const_generics)]
     pub fn get_disjoint_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]> {
         // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
         // safe because the type we are claiming to have initialized here is a
@@ -851,7 +860,6 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// assert_eq!(sm[ka], "apples");
     /// assert_eq!(sm[kb], "butter");
     /// ```
-    #[cfg(has_min_const_generics)]
     pub unsafe fn get_disjoint_unchecked_mut<const N: usize>(
         &mut self,
         keys: [K; N],
@@ -880,7 +888,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     ///     println!("key: {:?}, val: {}", k, v);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             cur: unsafe { self.slots.get_unchecked(0).u.free.other_end as usize + 1 },
             num_left: self.len(),
@@ -912,7 +920,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// assert_eq!(sm[k1], 20);
     /// assert_eq!(sm[k2], -30);
     /// ```
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut {
             cur: 0,
             num_left: self.len(),
@@ -937,7 +945,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// let check: HashSet<_> = vec![k0, k1, k2].into_iter().collect();
     /// assert_eq!(keys, check);
     /// ```
-    pub fn keys(&self) -> Keys<K, V> {
+    pub fn keys(&self) -> Keys<'_, K, V> {
         Keys { inner: self.iter() }
     }
 
@@ -957,7 +965,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// let check: HashSet<_> = vec![&10, &20, &30].into_iter().collect();
     /// assert_eq!(values, check);
     /// ```
-    pub fn values(&self) -> Values<K, V> {
+    pub fn values(&self) -> Values<'_, K, V> {
         Values { inner: self.iter() }
     }
 
@@ -978,7 +986,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// let check: HashSet<_> = vec![3, 6, 9].into_iter().collect();
     /// assert_eq!(values, check);
     /// ```
-    pub fn values_mut(&mut self) -> ValuesMut<K, V> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
@@ -1071,7 +1079,7 @@ impl<'a, K: 'a + Key, V: 'a> Clone for Iter<'a, K, V> {
             cur: self.cur,
             num_left: self.num_left,
             slots: self.slots,
-            _k: self._k.clone(),
+            _k: self._k,
         }
     }
 }
@@ -1133,7 +1141,7 @@ impl<'a, K: Key, V> Iterator for Drain<'a, K, V> {
     fn next(&mut self) -> Option<(K, V)> {
         // All unchecked indices are safe due to the invariants of the freelist
         // and that self.sm.len() guarantees there is another element.
-        if self.sm.len() == 0 {
+        if self.sm.is_empty() {
             return None;
         }
 
@@ -1145,7 +1153,9 @@ impl<'a, K: Key, V> Iterator for Drain<'a, K, V> {
             None => 0,
         };
 
-        let key = KeyData::new(idx as u32, unsafe { self.sm.slots.get_unchecked(idx).version });
+        let key = KeyData::new(idx as u32, unsafe {
+            self.sm.slots.get_unchecked(idx).version
+        });
         Some((key.into(), unsafe { self.sm.remove_from_slot(idx) }))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,27 +10,12 @@
     unused_lifetimes,
     unused_import_braces
 )]
-#![deny(missing_docs, unaligned_references)]
-#![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        // Style differences.
-        module_name_repetitions,
-        redundant_closure_for_method_calls,
-        unseparated_literal_suffix,
-
-        // I know what I'm doing and want these.
-        wildcard_imports,
-        inline_always,
-        cast_possible_truncation,
-        needless_pass_by_value,
-
-        // Very noisy.
-        missing_errors_doc,
-        must_use_candidate
-    ))]
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![allow(
+    clippy::while_let_on_iterator, // Style differences.
+    clippy::unnecessary_map_or // Too high MSRV.
+)]
 
 //! # slotmap
 //!
@@ -208,10 +193,11 @@ extern crate alloc;
 // So our macros can refer to these.
 #[doc(hidden)]
 pub mod __impl {
-    #[cfg(feature = "serde")]
-    pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
     pub use core::convert::From;
     pub use core::result::Result;
+
+    #[cfg(feature = "serde")]
+    pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
 }
 
 pub mod basic;
@@ -273,11 +259,11 @@ impl KeyData {
     }
 
     fn null() -> Self {
-        Self::new(core::u32::MAX, 1)
+        Self::new(u32::MAX, 1)
     }
 
     fn is_null(self) -> bool {
-        self.idx == core::u32::MAX
+        self.idx == u32::MAX
     }
 
     /// Returns the key data as a 64-bit integer. No guarantees about its value
@@ -319,8 +305,7 @@ impl Default for KeyData {
     }
 }
 
-impl Hash for KeyData
-{
+impl Hash for KeyData {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // A derived Hash impl would call write_u32 twice. We call write_u64
         // once, which is beneficial if the hasher implements write_u64
@@ -343,6 +328,10 @@ impl Hash for KeyData
 /// The internal unsafe code relies on this, therefore this trait is `unsafe` to
 /// implement. It is strongly suggested to simply use [`new_key_type!`] instead
 /// of implementing this trait yourself.
+///
+/// # Safety
+/// All methods and trait implementations must behave exactly as if we're
+/// operating on a [`KeyData`] directly.
 pub unsafe trait Key:
     From<KeyData>
     + Copy
@@ -572,12 +561,12 @@ mod tests {
         use super::new_key_type;
 
         // Clobber namespace with clashing names - should still work.
-        trait Serialize { }
-        trait Deserialize { }
-        trait Serializer { }
-        trait Deserializer { }
-        trait Key { }
-        trait From { }
+        trait Serialize {}
+        trait Deserialize {}
+        trait Serializer {}
+        trait Deserializer {}
+        trait Key {}
+        trait From {}
         struct Result;
         struct KeyData;
 

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -457,7 +457,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// assert_eq!(sec.len(), 0);
     /// assert_eq!(v, vec![(k, 1)]);
     /// ```
-    pub fn drain(&mut self) -> Drain<K, V> {
+    pub fn drain(&mut self) -> Drain<'_, K, V> {
         Drain { cur: 1, sm: self }
     }
 
@@ -581,7 +581,6 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// assert_eq!(sec[ka], "apples");
     /// assert_eq!(sec[kb], "butter");
     /// ```
-    #[cfg(has_min_const_generics)]
     pub fn get_disjoint_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]> {
         // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
         // safe because the type we are claiming to have initialized here is a
@@ -655,7 +654,6 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// assert_eq!(sec[ka], "apples");
     /// assert_eq!(sec[kb], "butter");
     /// ```
-    #[cfg(has_min_const_generics)]
     pub unsafe fn get_disjoint_unchecked_mut<const N: usize>(
         &mut self,
         keys: [K; N],
@@ -688,7 +686,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     ///     println!("key: {:?}, val: {}", k, v);
     /// }
     /// ```
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             num_left: self.num_elems,
             slots: self.slots.iter().enumerate(),
@@ -723,7 +721,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// assert_eq!(sec[k1], 20);
     /// assert_eq!(sec[k2], -30);
     /// ```
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut {
             num_left: self.num_elems,
             slots: self.slots.iter_mut().enumerate(),
@@ -751,7 +749,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// let check: HashSet<_> = vec![k0, k1, k2].into_iter().collect();
     /// assert_eq!(keys, check);
     /// ```
-    pub fn keys(&self) -> Keys<K, V> {
+    pub fn keys(&self) -> Keys<'_, K, V> {
         Keys { inner: self.iter() }
     }
 
@@ -775,7 +773,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// let check: HashSet<_> = vec![&10, &20, &30].into_iter().collect();
     /// assert_eq!(values, check);
     /// ```
-    pub fn values(&self) -> Values<K, V> {
+    pub fn values(&self) -> Values<'_, K, V> {
         Values { inner: self.iter() }
     }
 
@@ -800,7 +798,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// let check: HashSet<_> = vec![30, 60, 90].into_iter().collect();
     /// assert_eq!(values, check);
     /// ```
-    pub fn values_mut(&mut self) -> ValuesMut<K, V> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
@@ -820,7 +818,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
     /// let v = sec.entry(k).unwrap().or_insert(10);
     /// assert_eq!(*v, 10);
     /// ```
-    pub fn entry(&mut self, key: K) -> Option<Entry<K, V>> {
+    pub fn entry(&mut self, key: K) -> Option<Entry<'_, K, V>> {
         if key.is_null() {
             return None;
         }
@@ -883,8 +881,11 @@ impl<K: Key, V: PartialEq> PartialEq for SecondaryMap<K, V> {
             return false;
         }
 
-        self.iter()
-            .all(|(key, value)| other.get(key).map_or(false, |other_value| *value == *other_value))
+        self.iter().all(|(key, value)| {
+            other
+                .get(key)
+                .map_or(false, |other_value| *value == *other_value)
+        })
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use core::fmt::Debug;
-use core::hint::unreachable_unchecked;
 
 /// Internal stable replacement for !.
 #[derive(Debug)]
@@ -10,39 +9,6 @@ pub enum Never {}
 pub fn is_older_version(a: u32, b: u32) -> bool {
     let diff = a.wrapping_sub(b);
     diff >= (1 << 31)
-}
-
-/// An unwrapper that checks on debug, doesn't check on release.
-/// UB if unwrapped on release mode when unwrap would panic.
-pub trait UnwrapUnchecked<T> {
-    // Extra underscore because unwrap_unchecked is planned to be added to the stdlib.
-    unsafe fn unwrap_unchecked_(self) -> T;
-}
-
-impl<T> UnwrapUnchecked<T> for Option<T> {
-    unsafe fn unwrap_unchecked_(self) -> T {
-        if cfg!(debug_assertions) {
-            self.unwrap()
-        } else {
-            match self {
-                Some(x) => x,
-                None => unreachable_unchecked(),
-            }
-        }
-    }
-}
-
-impl<T, E: Debug> UnwrapUnchecked<T> for Result<T, E> {
-    unsafe fn unwrap_unchecked_(self) -> T {
-        if cfg!(debug_assertions) {
-            self.unwrap()
-        } else {
-            match self {
-                Ok(x) => x,
-                Err(_) => unreachable_unchecked(),
-            }
-        }
-    }
 }
 
 pub struct PanicOnDrop(pub &'static str);


### PR DESCRIPTION
Ran `cargo fmt`, made clippy pass again.

Bumped MSRV (and documented MSRV) to 1.58. This let me remove some old cruft.