### PR TITLE
Add as_slice methods to DenseSlotMap.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,8 @@ Version 1.1.0
 
  - Bumped MSRV to 1.58.
  - Fixed memory leak in `clone_from`.
+ - Added `keys_as_slice`, `values_as_slice`, and `values_as_mut_slice` to
+   `DenseSlotMap`.
 
 Version 1.0.7
 =============

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -555,8 +555,8 @@ impl<K: Key, V> SlotMap<K, V> {
         self.drain();
     }
 
-    /// Clears the slot map, returning all key-value pairs in arbitrary order as
-    /// an iterator. Keeps the allocated memory for reuse.
+    /// Clears the slot map, returning all key-value pairs in an arbitrary order
+    /// as an iterator. Keeps the allocated memory for reuse.
     ///
     /// When the iterator is dropped all elements in the slot map are removed,
     /// even if the iterator was not fully consumed. If the iterator is not
@@ -767,7 +767,7 @@ impl<K: Key, V> SlotMap<K, V> {
         core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order. The
+    /// An iterator visiting all key-value pairs in an arbitrary order. The
     /// iterator element type is `(K, &'a V)`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
@@ -796,7 +796,7 @@ impl<K: Key, V> SlotMap<K, V> {
         }
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order, with
+    /// An iterator visiting all key-value pairs in an arbitrary order, with
     /// mutable references to the values. The iterator element type is
     /// `(K, &'a mut V)`.
     ///
@@ -833,8 +833,8 @@ impl<K: Key, V> SlotMap<K, V> {
         }
     }
 
-    /// An iterator visiting all keys in arbitrary order. The iterator element
-    /// type is `K`.
+    /// An iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is `K`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.
@@ -856,8 +856,8 @@ impl<K: Key, V> SlotMap<K, V> {
         Keys { inner: self.iter() }
     }
 
-    /// An iterator visiting all values in arbitrary order. The iterator element
-    /// type is `&'a V`.
+    /// An iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.
@@ -879,8 +879,8 @@ impl<K: Key, V> SlotMap<K, V> {
         Values { inner: self.iter() }
     }
 
-    /// An iterator visiting all values mutably in arbitrary order. The iterator
-    /// element type is `&'a mut V`.
+    /// An iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -455,7 +455,7 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         self.drain();
     }
 
-    /// Clears the slot map, returning all key-value pairs in arbitrary order
+    /// Clears the slot map, returning all key-value pairs in an arbitrary order
     /// as an iterator. Keeps the allocated memory for reuse.
     ///
     /// When the iterator is dropped all elements in the slot map are removed,
@@ -679,7 +679,7 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order. The
+    /// An iterator visiting all key-value pairs in an arbitrary order. The
     /// iterator element type is `(K, &'a V)`.
     ///
     /// # Examples
@@ -703,7 +703,7 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         }
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order, with
+    /// An iterator visiting all key-value pairs in an arbitrary order, with
     /// mutable references to the values. The iterator element type is
     /// `(K, &'a mut V)`.
     ///
@@ -733,8 +733,8 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         }
     }
 
-    /// An iterator visiting all keys in arbitrary order. The iterator element
-    /// type is K.
+    /// An iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is K.
     ///
     /// # Examples
     ///
@@ -753,8 +753,8 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         Keys { inner: self.iter() }
     }
 
-    /// An iterator visiting all values in arbitrary order. The iterator element
-    /// type is `&'a V`.
+    /// An iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
     ///
     /// # Examples
     ///
@@ -773,8 +773,8 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         Values { inner: self.iter() }
     }
 
-    /// An iterator visiting all values mutably in arbitrary order. The iterator
-    /// element type is `&'a mut V`.
+    /// An iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
     ///
     /// # Examples
     ///
@@ -794,6 +794,72 @@ impl<K: Key, V> DenseSlotMap<K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
+    }
+
+    /// Returns a slice containing all keys in the slot map in an arbitrary
+    /// order (but in the same order as [`values_as_slice`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm = DenseSlotMap::new();
+    /// let k1 = sm.insert(1);
+    /// let k2 = sm.insert(2);
+    /// sm.remove(k1);
+    /// sm.insert(3);
+    /// let key_slice = sm.keys_as_slice();
+    /// // The order is arbitrary, but we can check if the keys are present.
+    /// assert!(key_slice.contains(&k2));
+    /// assert_eq!(key_slice.len(), 2);
+    /// // The keys correspond to the values.
+    /// assert_eq!(sm.values_as_slice()[0], sm[key_slice[0]]);
+    /// ```
+    pub fn keys_as_slice(&self) -> &[K] {
+        self.keys.as_slice()
+    }
+
+    /// Returns a slice containing all values in the slot map in an arbitrary
+    /// order (but in the same order as [`keys_as_slice`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use std::collections::HashSet;
+    /// let mut sm = DenseSlotMap::new();
+    /// sm.insert(10);
+    /// sm.insert(20);
+    /// sm.insert(30);
+    /// let value_slice = sm.values_as_slice();
+    /// let values: HashSet<_> = value_slice.iter().collect();
+    /// let check: HashSet<_> = vec![&10, &20, &30].into_iter().collect();
+    /// assert_eq!(values, check);
+    /// // The keys correspond to the values.
+    /// assert_eq!(value_slice[0], sm[sm.keys_as_slice()[0]]);
+    /// ```
+    pub fn values_as_slice(&self) -> &[V] {
+        self.values.as_slice()
+    }
+
+    /// Returns a mutable slice containing all values in the slot map in
+    /// an arbitrary order (but in the same order as [`keys_as_slice`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// # use std::collections::HashSet;
+    /// let mut sm = DenseSlotMap::new();
+    /// sm.insert(1);
+    /// sm.insert(2);
+    /// sm.insert(3);
+    /// let slice = sm.values_as_mut_slice();
+    /// slice.iter_mut().for_each(|n| { *n *= 3 });
+    /// assert_eq!(slice, &[3, 6, 9]);
+    /// ```
+    pub fn values_as_mut_slice(&mut self) -> &mut [V] {
+        self.values.as_mut_slice()
     }
 }
 

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -654,8 +654,8 @@ impl<K: Key, V> HopSlotMap<K, V> {
         self.drain();
     }
 
-    /// Clears the slot map, returning all key-value pairs in arbitrary order as
-    /// an iterator. Keeps the allocated memory for reuse.
+    /// Clears the slot map, returning all key-value pairs in an arbitrary order
+    /// as an iterator. Keeps the allocated memory for reuse.
     ///
     /// When the iterator is dropped all elements in the slot map are removed,
     /// even if the iterator was not fully consumed. If the iterator is not
@@ -872,7 +872,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
         core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order. The
+    /// An iterator visiting all key-value pairs in an arbitrary order. The
     /// iterator element type is `(K, &'a V)`.
     ///
     /// # Examples
@@ -897,7 +897,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
         }
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order, with
+    /// An iterator visiting all key-value pairs in an arbitrary order, with
     /// mutable references to the values. The iterator element type is
     /// `(K, &'a mut V)`.
     ///
@@ -929,8 +929,8 @@ impl<K: Key, V> HopSlotMap<K, V> {
         }
     }
 
-    /// An iterator visiting all keys in arbitrary order. The iterator element
-    /// type is `K`.
+    /// An iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is `K`.
     ///
     /// # Examples
     ///
@@ -949,8 +949,8 @@ impl<K: Key, V> HopSlotMap<K, V> {
         Keys { inner: self.iter() }
     }
 
-    /// An iterator visiting all values in arbitrary order. The iterator element
-    /// type is `&'a V`.
+    /// An iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
     ///
     /// # Examples
     ///
@@ -969,8 +969,8 @@ impl<K: Key, V> HopSlotMap<K, V> {
         Values { inner: self.iter() }
     }
 
-    /// An iterator visiting all values mutably in arbitrary order. The iterator
-    /// element type is `&'a mut V`.
+    /// An iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
     ///
     /// # Examples
     ///

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -433,8 +433,8 @@ impl<K: Key, V> SecondaryMap<K, V> {
         self.drain();
     }
 
-    /// Clears the slot map, returning all key-value pairs in arbitrary order as
-    /// an iterator. Keeps the allocated memory for reuse.
+    /// Clears the slot map, returning all key-value pairs in an arbitrary order
+    /// as an iterator. Keeps the allocated memory for reuse.
     ///
     /// When the iterator is dropped all elements in the slot map are removed,
     /// even if the iterator was not fully consumed. If the iterator is not
@@ -666,7 +666,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
         core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order. The
+    /// An iterator visiting all key-value pairs in an arbitrary order. The
     /// iterator element type is `(K, &'a V)`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
@@ -694,7 +694,7 @@ impl<K: Key, V> SecondaryMap<K, V> {
         }
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order, with
+    /// An iterator visiting all key-value pairs in an arbitrary order, with
     /// mutable references to the values. The iterator element type is
     /// `(K, &'a mut V)`.
     ///
@@ -729,8 +729,8 @@ impl<K: Key, V> SecondaryMap<K, V> {
         }
     }
 
-    /// An iterator visiting all keys in arbitrary order. The iterator element
-    /// type is `K`.
+    /// An iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is `K`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.
@@ -753,8 +753,8 @@ impl<K: Key, V> SecondaryMap<K, V> {
         Keys { inner: self.iter() }
     }
 
-    /// An iterator visiting all values in arbitrary order. The iterator element
-    /// type is `&'a V`.
+    /// An iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.
@@ -777,8 +777,8 @@ impl<K: Key, V> SecondaryMap<K, V> {
         Values { inner: self.iter() }
     }
 
-    /// An iterator visiting all values mutably in arbitrary order. The iterator
-    /// element type is `&'a mut V`.
+    /// An iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -400,8 +400,8 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
         self.slots.clear();
     }
 
-    /// Clears the slot map, returning all key-value pairs in arbitrary order as
-    /// an iterator. Keeps the allocated memory for reuse.
+    /// Clears the slot map, returning all key-value pairs in an arbitrary order
+    /// as an iterator. Keeps the allocated memory for reuse.
     ///
     /// When the iterator is dropped all elements in the slot map are removed,
     /// even if the iterator was not fully consumed. If the iterator is not
@@ -625,7 +625,7 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
         core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order. The
+    /// An iterator visiting all key-value pairs in an arbitrary order. The
     /// iterator element type is `(K, &'a V)`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
@@ -652,7 +652,7 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
         }
     }
 
-    /// An iterator visiting all key-value pairs in arbitrary order, with
+    /// An iterator visiting all key-value pairs in an arbitrary order, with
     /// mutable references to the values. The iterator element type is
     /// `(K, &'a mut V)`.
     ///
@@ -686,8 +686,8 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
         }
     }
 
-    /// An iterator visiting all keys in arbitrary order. The iterator element
-    /// type is `K`.
+    /// An iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is `K`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.
@@ -710,8 +710,8 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
         Keys { inner: self.iter() }
     }
 
-    /// An iterator visiting all values in arbitrary order. The iterator element
-    /// type is `&'a V`.
+    /// An iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.
@@ -734,8 +734,8 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
         Values { inner: self.iter() }
     }
 
-    /// An iterator visiting all values mutably in arbitrary order. The iterator
-    /// element type is `&'a mut V`.
+    /// An iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
     ///
     /// This function must iterate over all slots, empty or not. In the face of
     /// many deleted elements it can be inefficient.


### PR DESCRIPTION
Supersedes https://github.com/orlp/slotmap/pull/134.

Fixes https://github.com/orlp/slotmap/issues/131.

Credit to @Swiiz for the examples.