### PR TITLE
Update Debug impl for KeyData to nicely format nulls.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@ Version 1.1.0
  - Fixed memory leak in `clone_from`.
  - Added `keys_as_slice`, `values_as_slice`, and `values_as_mut_slice` to
    `DenseSlotMap`.
+ - Ensured that `is_null()` keys print as `null` in their `Debug` representation.
 
 Version 1.0.7
 =============

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,11 @@ impl KeyData {
 
 impl Debug for KeyData {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}v{}", self.idx, self.version.get())
+        if self.is_null() {
+            f.write_str("null")
+        } else {
+            write!(f, "{}v{}", self.idx, self.version.get())
+        }
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/orlp/slotmap/issues/126.