### PR TITLE
Resolve Miri error for get_disjoint_mut under Stacked Borrows.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,8 @@ Version 1.1.0
  - Added `keys_as_slice`, `values_as_slice`, and `values_as_mut_slice` to
    `DenseSlotMap`.
  - Ensured that `is_null()` keys print as `null` in their `Debug` representation.
+ - Made `KeyData::new` and `KeyData::from_ffi` const.
+ - Resolved a Miri error in `get_disjoint_mut` under the Stacked Borrows model.
 
 Version 1.0.7
 =============

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -798,14 +798,11 @@ impl<K: Key, V> HopSlotMap<K, V> {
     /// assert_eq!(sm[kb], "butter");
     /// ```
     pub fn get_disjoint_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]> {
-        // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
-        // safe because the type we are claiming to have initialized here is a
-        // bunch of `MaybeUninit`s, which do not require initialization.
-        let mut ptrs: [MaybeUninit<*mut V>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut ptrs: [MaybeUninit<*mut V>; N] = [(); N].map(|_| MaybeUninit::uninit());
+        let slots_ptr = self.slots.as_mut_ptr();
 
         let mut i = 0;
         while i < N {
-            // We can avoid this clone after min_const_generics and array_map.
             let kd = keys[i].data();
             if !self.contains_key(kd.into()) {
                 break;
@@ -815,7 +812,7 @@ impl<K: Key, V> HopSlotMap<K, V> {
             // mark it as unoccupied so duplicate keys would show up as invalid.
             // This gives us a linear time disjointness check.
             unsafe {
-                let slot = self.slots.get_unchecked_mut(kd.idx as usize);
+                let slot = &mut *slots_ptr.add(kd.idx as usize);
                 slot.version ^= 1;
                 ptrs[i] = MaybeUninit::new(&mut *slot.u.value);
             }
@@ -826,13 +823,13 @@ impl<K: Key, V> HopSlotMap<K, V> {
         for k in &keys[..i] {
             let idx = k.data().idx as usize;
             unsafe {
-                self.slots.get_unchecked_mut(idx).version ^= 1;
+                (*slots_ptr.add(idx)).version ^= 1;
             }
         }
 
         if i == N {
             // All were valid and disjoint.
-            Some(unsafe { core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs) })
+            Some(ptrs.map(|p| unsafe { &mut *p.assume_init() }))
         } else {
             None
         }
@@ -864,12 +861,11 @@ impl<K: Key, V> HopSlotMap<K, V> {
         &mut self,
         keys: [K; N],
     ) -> [&mut V; N] {
-        // Safe, see get_disjoint_mut.
-        let mut ptrs: [MaybeUninit<*mut V>; N] = MaybeUninit::uninit().assume_init();
-        for i in 0..N {
-            ptrs[i] = MaybeUninit::new(self.get_unchecked_mut(keys[i]));
-        }
-        core::mem::transmute_copy::<_, [&mut V; N]>(&ptrs)
+        let slots_ptr = self.slots.as_mut_ptr();
+        keys.map(|k| unsafe {
+            let slot = &mut *slots_ptr.add(k.data().idx as usize);
+            &mut *slot.u.value
+        })
     }
 
     /// An iterator visiting all key-value pairs in an arbitrary order. The

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -547,11 +547,7 @@ impl<K: Key, V, S: hash::BuildHasher> SparseSecondaryMap<K, V, S> {
     /// assert_eq!(sec[kb], "butter");
     /// ```
     pub fn get_disjoint_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]> {
-        // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
-        // safe because the type we are claiming to have initialized here is a
-        // bunch of `MaybeUninit`s, which do not require initialization.
-        let mut ptrs: [MaybeUninit<*mut V>; N] = unsafe { MaybeUninit::uninit().assume_init() };
-
+        let mut ptrs: [MaybeUninit<*mut V>; N] = [(); N].map(|_| MaybeUninit::uninit());
         let mut i = 0;
         while i < N {
             let kd = keys[i].data();


### PR DESCRIPTION
This is mainly done to make the life of people who want to use Miri easier, in my opinion the original code was sound and Miri also agrees that it's sound under the Tree Borrows model.

Mostly resolves https://github.com/orlp/slotmap/issues/92. Only `get_disjoint_mut` for `SparseSecondaryMap` still triggers the error which I can't resolve unless I put my MSRV to 1.86 for `HashMap::get_disjoint_mut`.