### PR TITLE
Add detach/reattach to (Dense)SlotMap.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,9 @@ Version 1.1.0
  - Ensured that `is_null()` keys print as `null` in their `Debug` representation.
  - Made `KeyData::new` and `KeyData::from_ffi` const.
  - Resolved a Miri error in `get_disjoint_mut` under the Stacked Borrows model.
+ - Added `detach` and `reattach` methods to `SlotMap` and `DenseSlotMap` which
+   let you temporarily remove key/value pairs from the slot map before
+   adding them back.
 
 Version 1.0.7
 =============

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ impl<T> Slottable for T {}
 
 /// The actual data stored in a [`Key`].
 ///
-/// This implements [`Ord`](std::cmp::Ord) so keys can be stored in e.g.
+/// This implements [`Ord`] so keys can be stored in e.g.
 /// [`BTreeMap`](std::collections::BTreeMap), but the order of keys is
 /// unspecified.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Resolves https://github.com/orlp/slotmap/issues/75.

I originally had pushed this back to 2.0 because the serialization format would need to change to preserve detached keys. However I'm fine with adding it right now with the caveat that detached keys become deleted keys during serialization.