### PR TITLE
Fix uninit data in HopSlotMap freelist

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1502,13 +1502,8 @@ mod tests {
             let mut sm = SlotMap::new();
             let mut sm_keys = Vec::new();
 
-            #[cfg(not(feature = "serde"))]
-            let num_ops = 3;
-            #[cfg(feature = "serde")]
-            let num_ops = 4;
-
             for (op, val) in operations {
-                match op % num_ops {
+                match op % 4 {
                     // Insert.
                     0 => {
                         hm.insert(unique_key, val);
@@ -1548,11 +1543,17 @@ mod tests {
                         }
                     }
 
-                    // Serde round-trip.
-                    #[cfg(feature = "serde")]
+                    // Round-trip/clone.
                     3 => {
-                        let ser = serde_json::to_string(&sm).unwrap();
-                        sm = serde_json::from_str(&ser).unwrap();
+                        if val % 2 == 0 {
+                            #[cfg(feature = "serde")]
+                            {
+                                let ser = serde_json::to_string(&sm).unwrap();
+                                sm = serde_json::from_str(&ser).unwrap();
+                            }
+                        } else {
+                            sm = sm.clone();
+                        }
                     }
 
                     _ => unreachable!(),

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1482,13 +1482,8 @@ mod tests {
             let mut sm = DenseSlotMap::new();
             let mut sm_keys = Vec::new();
 
-            #[cfg(not(feature = "serde"))]
-            let num_ops = 3;
-            #[cfg(feature = "serde")]
-            let num_ops = 4;
-
             for (op, val) in operations {
-                match op % num_ops {
+                match op % 4 {
                     // Insert.
                     0 => {
                         hm.insert(unique_key, val);
@@ -1528,11 +1523,17 @@ mod tests {
                         }
                     }
 
-                    // Serde round-trip.
-                    #[cfg(feature = "serde")]
+                    // Round-trip/clone.
                     3 => {
-                        let ser = serde_json::to_string(&sm).unwrap();
-                        sm = serde_json::from_str(&ser).unwrap();
+                        if val % 2 == 0 {
+                            #[cfg(feature = "serde")]
+                            {
+                                let ser = serde_json::to_string(&sm).unwrap();
+                                sm = serde_json::from_str(&ser).unwrap();
+                            }
+                        } else {
+                            sm = sm.clone();
+                        }
                     }
 
                     _ => unreachable!(),

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -511,9 +511,9 @@ impl<K: Key, V> HopSlotMap<K, V> {
                 self.freelist(0).prev = i;
                 self.freelist(old_tail).next = i;
                 *self.freelist(i) = FreeListEntry {
-                    other_end: i,
                     next: 0,
                     prev: old_tail,
+                    other_end: i,
                 };
             },
 
@@ -531,8 +531,12 @@ impl<K: Key, V> HopSlotMap<K, V> {
             (true, false) => {
                 // Append to vacant block on left.
                 let front = self.freelist(i - 1).other_end;
-                self.freelist(i).other_end = front;
                 self.freelist(front).other_end = i;
+                *self.freelist(i) = FreeListEntry {
+                    next: 0, // Unused.
+                    prev: 0, // Unused.
+                    other_end: front,
+                };
             },
 
             (true, true) => {
@@ -547,6 +551,12 @@ impl<K: Key, V> HopSlotMap<K, V> {
                 let back = right.other_end;
                 self.freelist(front).other_end = back;
                 self.freelist(back).other_end = front;
+
+                *self.freelist(i) = FreeListEntry {
+                    next: 0,      // Unused.
+                    prev: 0,      // Unused.
+                    other_end: 0, // Unused.
+                };
             },
         }
 
@@ -1577,13 +1587,8 @@ mod tests {
             let mut sm = HopSlotMap::new();
             let mut sm_keys = Vec::new();
 
-            #[cfg(not(feature = "serde"))]
-            let num_ops = 3;
-            #[cfg(feature = "serde")]
-            let num_ops = 4;
-
             for (op, val) in operations {
-                match op % num_ops {
+                match op % 4 {
                     // Insert.
                     0 => {
                         hm.insert(unique_key, val);
@@ -1623,11 +1628,17 @@ mod tests {
                         }
                     }
 
-                    // Serde round-trip.
-                    #[cfg(feature = "serde")]
+                    // Round-trip/clone.
                     3 => {
-                        let ser = serde_json::to_string(&sm).unwrap();
-                        sm = serde_json::from_str(&ser).unwrap();
+                        if val % 2 == 0 {
+                            #[cfg(feature = "serde")]
+                            {
+                                let ser = serde_json::to_string(&sm).unwrap();
+                                sm = serde_json::from_str(&ser).unwrap();
+                            }
+                        } else {
+                            sm = sm.clone();
+                        }
                     }
 
                     _ => unreachable!(),


### PR DESCRIPTION
Found by @Shnatsel, the `HopSlotMap` implementation could have uninit fields in the `FreeListEntry`. This uninit data was never actually used by the algorithm itself, but could trigger UB in Miri when 'read' in `Clone` (which is just propagating it), or cause garbage output in `Debug`.

I have chosen not to yank the previous versions as I don't think this is a serious problem, even if technically UB.