### PR TITLE
Add allocator API support to basic Slotmap type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,9 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "byteorder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +191,7 @@ dependencies = [
 name = "slotmap"
 version = "1.1.1"
 dependencies = [
+ "allocator-api2",
  "fxhash",
  "quickcheck",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["std"]
 unstable = []
 std = []
 nightly = []
+serde = ["dep:serde", "allocator-api2?/serde"]
 
 [dependencies]
 allocator-api2 = { version = "0.2.18", optional = true, default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ categories = ["data-structures", "memory-management", "caching"]
 rust-version = "1.58.0"
 
 [features]
-default = ["std"]
+default = ["std", "allocator-api2"]
 unstable = []
 std = []
+nightly = []
 
 [dependencies]
+allocator-api2 = { version = "0.2.18", optional = true, default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["data-structures", "memory-management", "caching"]
 rust-version = "1.58.0"
 
 [features]
-default = ["std", "allocator-api2"]
+default = ["std"]
 unstable = []
 std = []
 nightly = []

--- a/src/alloc_impl.rs
+++ b/src/alloc_impl.rs
@@ -64,6 +64,8 @@ mod _impl_ {
         core::alloc::Allocator,
         alloc::alloc::Global,
     };
+    #[cfg(test)] pub use alloc::alloc::AllocError;
+    
     use std::ops::{Deref, DerefMut};
 
     #[repr(transparent)]
@@ -113,6 +115,8 @@ mod _impl_ {
         alloc::Allocator,
         alloc::Global,
     };
+    #[cfg(test)] pub use allocator_api2::alloc::AllocError;
+
     use std::ops::{Deref, DerefMut};
 
     #[repr(transparent)]

--- a/src/alloc_impl.rs
+++ b/src/alloc_impl.rs
@@ -1,6 +1,5 @@
-
 // Configure Vec/allocation imports based on features.
-// We implement a common api depending on the nightly/allocator-api2 
+// We implement a common api depending on the nightly/allocator-api2
 // features, which is consumed uniformly by the impls.
 pub use _impl_::*;
 
@@ -9,7 +8,8 @@ pub use _impl_::*;
 #[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
 mod _impl_ {
     pub use alloc::collections::TryReserveError;
-    use {std::{marker::PhantomData, ops::{Deref, DerefMut}}};
+    use std::marker::PhantomData;
+    use std::ops::{Deref, DerefMut};
 
     pub trait Allocator {}
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -20,114 +20,159 @@ mod _impl_ {
     #[derive(Debug, Clone)]
     pub struct VecWrap<T, A: Allocator = Global>(alloc::vec::Vec<T>, PhantomData<A>);
 
-    impl <T, A: Allocator> VecWrap<T, A> {
-        #[inline(always)] pub fn wrap(inner: alloc::vec::Vec<T>) -> Self { Self(inner, PhantomData) }
-        #[inline(always)] pub fn try_with_capacity_in(capacity: usize, _allocator: A) -> Result<Self, TryReserveError> { Ok(Self::wrap(Vec::with_capacity(capacity))) }
+    impl<T, A: Allocator> VecWrap<T, A> {
+        #[inline(always)]
+        pub fn wrap(inner: alloc::vec::Vec<T>) -> Self {
+            Self(inner, PhantomData)
+        }
+        #[inline(always)]
+        pub fn try_with_capacity_in(
+            capacity: usize,
+            _allocator: A,
+        ) -> Result<Self, TryReserveError> {
+            Ok(Self::wrap(Vec::with_capacity(capacity)))
+        }
     }
 
-    impl <T, A: Allocator> Deref for VecWrap<T, A> {
+    impl<T, A: Allocator> Deref for VecWrap<T, A> {
         type Target = alloc::vec::Vec<T>;
-        #[inline(always)] fn deref(&self) -> &Self::Target { &self.0 }
+        #[inline(always)]
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
     }
 
-    impl <T, A: Allocator> DerefMut for VecWrap<T, A> {
-        #[inline(always)] fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    impl<T, A: Allocator> DerefMut for VecWrap<T, A> {
+        #[inline(always)]
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
     }
 
-    impl <T, A: Allocator> IntoIterator for VecWrap<T, A> {
+    impl<T, A: Allocator> IntoIterator for VecWrap<T, A> {
         type Item = <<Self as Deref>::Target as IntoIterator>::Item;
         type IntoIter = <<Self as Deref>::Target as IntoIterator>::IntoIter;
-        fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
+        #[inline(always)]
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
     }
 
     #[repr(transparent)]
     #[derive(Debug, Clone)]
     pub struct VecIntoIterWrap<T, A: Allocator = Global>(alloc::vec::IntoIter<T>, PhantomData<A>);
-    impl <T, A: Allocator> VecIntoIterWrap<T, A> {
+    impl<T, A: Allocator> VecIntoIterWrap<T, A> {
         #[inline(always)]
-        pub fn wrap(inner: alloc::vec::IntoIter<T>) -> Self { Self(inner, PhantomData) }
+        pub fn wrap(inner: alloc::vec::IntoIter<T>) -> Self {
+            Self(inner, PhantomData)
+        }
     }
 
-    impl <T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
+    impl<T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
         type Item = <alloc::vec::IntoIter<T> as Iterator>::Item;
-        #[inline(always)] fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+        #[inline(always)]
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
     }
-
-
 }
 
 // If on nightly: Use nightly allocator_api
 #[cfg(feature = "nightly")]
 mod _impl_ {
-    pub use {
-        alloc::collections::TryReserveError, 
-        core::alloc::Allocator,
-        alloc::alloc::Global,
-    };
-    #[cfg(test)] pub use alloc::alloc::AllocError;
-    
+    #[cfg(test)]
+    pub use alloc::alloc::AllocError;
+    pub use alloc::alloc::Global;
+    pub use alloc::collections::TryReserveError;
+    pub use core::alloc::Allocator;
     use std::ops::{Deref, DerefMut};
 
     #[repr(transparent)]
     #[derive(Debug, Clone)]
     pub struct VecWrap<T, A: Allocator = Global>(alloc::vec::Vec<T, A>);
 
-    impl <T, A: Allocator> VecWrap<T, A> {
-        #[inline(always)] pub fn wrap(inner: alloc::vec::Vec<T, A>) -> Self { Self(inner) }
-        #[inline(always)] pub fn try_with_capacity_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> { Ok(Self::wrap(Vec::try_with_capacity_in(capacity, allocator)?)) }
+    impl<T, A: Allocator> VecWrap<T, A> {
+        #[inline(always)]
+        pub fn wrap(inner: alloc::vec::Vec<T, A>) -> Self {
+            Self(inner)
+        }
+        #[inline(always)]
+        pub fn try_with_capacity_in(
+            capacity: usize,
+            allocator: A,
+        ) -> Result<Self, TryReserveError> {
+            Ok(Self::wrap(Vec::try_with_capacity_in(capacity, allocator)?))
+        }
     }
 
-    impl <T, A: Allocator> Deref for VecWrap<T, A> {
+    impl<T, A: Allocator> Deref for VecWrap<T, A> {
         type Target = alloc::vec::Vec<T, A>;
-        #[inline(always)] fn deref(&self) -> &Self::Target { &self.0 }
+        #[inline(always)]
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
     }
 
-    impl <T, A: Allocator> DerefMut for VecWrap<T, A> {
-        #[inline(always)] fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    impl<T, A: Allocator> DerefMut for VecWrap<T, A> {
+        #[inline(always)]
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
     }
 
-    impl <T, A: Allocator> IntoIterator for VecWrap<T, A> {
+    impl<T, A: Allocator> IntoIterator for VecWrap<T, A> {
         type Item = <<Self as Deref>::Target as IntoIterator>::Item;
         type IntoIter = <<Self as Deref>::Target as IntoIterator>::IntoIter;
-        fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
+        #[inline(always)]
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
     }
 
     #[repr(transparent)]
     #[derive(Debug, Clone)]
     pub struct VecIntoIterWrap<T, A: Allocator = Global>(alloc::vec::IntoIter<T, A>);
-    impl <T, A: Allocator> VecIntoIterWrap<T, A> {
-        #[inline(always)] pub fn wrap(inner: alloc::vec::IntoIter<T, A>) -> Self { Self(inner) }
+    impl<T, A: Allocator> VecIntoIterWrap<T, A> {
+        #[inline(always)]
+        pub fn wrap(inner: alloc::vec::IntoIter<T, A>) -> Self {
+            Self(inner)
+        }
     }
 
-    impl <T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
+    impl<T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
         type Item = <alloc::vec::IntoIter<T, A> as Iterator>::Item;
-        #[inline(always)] fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+        #[inline(always)]
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
     }
-
 }
 
 // If not on nightly, but allocator-api2 is enabled: use it
 #[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
 mod _impl_ {
-    pub use allocator_api2::{
-        vec::Vec as Vec,
-        collections::TryReserveError,
-        alloc::Allocator,
-        alloc::Global,
-    };
-    #[cfg(test)] pub use allocator_api2::alloc::AllocError;
-
     use std::ops::{Deref, DerefMut};
+
+    #[cfg(test)]
+    pub use allocator_api2::alloc::AllocError;
+    pub use allocator_api2::alloc::{Allocator, Global};
+    pub use allocator_api2::collections::TryReserveError;
+    pub use allocator_api2::vec::Vec;
 
     #[repr(transparent)]
     #[derive(Debug, Clone)]
     pub struct VecWrap<T, A: Allocator = Global>(allocator_api2::vec::Vec<T, A>);
 
-    impl <T, A: Allocator> VecWrap<T, A> {
+    impl<T, A: Allocator> VecWrap<T, A> {
         #[inline(always)]
-        pub fn wrap(inner: allocator_api2::vec::Vec<T, A>) -> Self { Self(inner) }
-        #[inline(always)] 
-        pub fn try_with_capacity_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
+        pub fn wrap(inner: allocator_api2::vec::Vec<T, A>) -> Self {
+            Self(inner)
+        }
+        #[inline(always)]
+        pub fn try_with_capacity_in(
+            capacity: usize,
+            allocator: A,
+        ) -> Result<Self, TryReserveError> {
             // try_with_capacity_in is unstable, so we emulate it with a try_reserve when not on nightly
             let mut vec = Vec::new_in(allocator);
             vec.try_reserve(capacity)?;
@@ -135,32 +180,44 @@ mod _impl_ {
         }
     }
 
-    impl <T, A: Allocator> Deref for VecWrap<T, A> {
+    impl<T, A: Allocator> Deref for VecWrap<T, A> {
         type Target = allocator_api2::vec::Vec<T, A>;
-        #[inline(always)] fn deref(&self) -> &Self::Target { &self.0 }
+        #[inline(always)]
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
     }
 
-    impl <T, A: Allocator> DerefMut for VecWrap<T, A> {
-        #[inline(always)] fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    impl<T, A: Allocator> DerefMut for VecWrap<T, A> {
+        #[inline(always)]
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
     }
 
-    impl <T, A: Allocator> IntoIterator for VecWrap<T, A> {
+    impl<T, A: Allocator> IntoIterator for VecWrap<T, A> {
         type Item = <<Self as Deref>::Target as IntoIterator>::Item;
         type IntoIter = <<Self as Deref>::Target as IntoIterator>::IntoIter;
-        fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
     }
 
     #[repr(transparent)]
     #[derive(Debug, Clone)]
     pub struct VecIntoIterWrap<T, A: Allocator = Global>(allocator_api2::vec::IntoIter<T, A>);
-    impl <T, A: Allocator> VecIntoIterWrap<T, A> {
+    impl<T, A: Allocator> VecIntoIterWrap<T, A> {
         #[inline(always)]
-        pub fn wrap(inner: allocator_api2::vec::IntoIter<T, A>) -> Self { Self(inner) }
+        pub fn wrap(inner: allocator_api2::vec::IntoIter<T, A>) -> Self {
+            Self(inner)
+        }
     }
 
-    impl <T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
+    impl<T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
         type Item = <allocator_api2::vec::IntoIter<T, A> as Iterator>::Item;
-        #[inline(always)] fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+        #[inline(always)]
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
     }
-
 }

--- a/src/alloc_impl.rs
+++ b/src/alloc_impl.rs
@@ -8,8 +8,9 @@ pub use _impl_::*;
 #[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
 mod _impl_ {
     pub use alloc::collections::TryReserveError;
-    use std::marker::PhantomData;
-    use std::ops::{Deref, DerefMut};
+    pub use alloc::vec::Vec;
+    use core::marker::PhantomData;
+    use core::ops::{Deref, DerefMut};
 
     pub trait Allocator {}
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -82,10 +83,10 @@ mod _impl_ {
 mod _impl_ {
     #[cfg(test)]
     pub use alloc::alloc::AllocError;
-    pub use alloc::alloc::Global;
+    pub use alloc::alloc::{Allocator, Global};
     pub use alloc::collections::TryReserveError;
-    pub use core::alloc::Allocator;
-    use std::ops::{Deref, DerefMut};
+    pub use alloc::vec::Vec;
+    use core::ops::{Deref, DerefMut};
 
     #[repr(transparent)]
     #[derive(Debug, Clone)]
@@ -151,7 +152,7 @@ mod _impl_ {
 // If not on nightly, but allocator-api2 is enabled: use it
 #[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
 mod _impl_ {
-    use std::ops::{Deref, DerefMut};
+    use core::ops::{Deref, DerefMut};
 
     #[cfg(test)]
     pub use allocator_api2::alloc::AllocError;

--- a/src/alloc_impl.rs
+++ b/src/alloc_impl.rs
@@ -1,0 +1,162 @@
+
+// Configure Vec/allocation imports based on features.
+// We implement a common api depending on the nightly/allocator-api2 
+// features, which is consumed uniformly by the impls.
+pub use _impl_::*;
+
+// If not on nightly, and no allocator-api2 enabled, use a normal alloc::Vec.
+// This should be the same behavior as before the features were added.
+#[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
+mod _impl_ {
+    pub use alloc::collections::TryReserveError;
+    use {std::{marker::PhantomData, ops::{Deref, DerefMut}}};
+
+    pub trait Allocator {}
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+    pub struct Global;
+    impl Allocator for Global {}
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct VecWrap<T, A: Allocator = Global>(alloc::vec::Vec<T>, PhantomData<A>);
+
+    impl <T, A: Allocator> VecWrap<T, A> {
+        #[inline(always)] pub fn wrap(inner: alloc::vec::Vec<T>) -> Self { Self(inner, PhantomData) }
+        #[inline(always)] pub fn try_with_capacity_in(capacity: usize, _allocator: A) -> Result<Self, TryReserveError> { Ok(Self::wrap(Vec::with_capacity(capacity))) }
+    }
+
+    impl <T, A: Allocator> Deref for VecWrap<T, A> {
+        type Target = alloc::vec::Vec<T>;
+        #[inline(always)] fn deref(&self) -> &Self::Target { &self.0 }
+    }
+
+    impl <T, A: Allocator> DerefMut for VecWrap<T, A> {
+        #[inline(always)] fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    }
+
+    impl <T, A: Allocator> IntoIterator for VecWrap<T, A> {
+        type Item = <<Self as Deref>::Target as IntoIterator>::Item;
+        type IntoIter = <<Self as Deref>::Target as IntoIterator>::IntoIter;
+        fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
+    }
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct VecIntoIterWrap<T, A: Allocator = Global>(alloc::vec::IntoIter<T>, PhantomData<A>);
+    impl <T, A: Allocator> VecIntoIterWrap<T, A> {
+        #[inline(always)]
+        pub fn wrap(inner: alloc::vec::IntoIter<T>) -> Self { Self(inner, PhantomData) }
+    }
+
+    impl <T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
+        type Item = <alloc::vec::IntoIter<T> as Iterator>::Item;
+        #[inline(always)] fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+    }
+
+
+}
+
+// If on nightly: Use nightly allocator_api
+#[cfg(feature = "nightly")]
+mod _impl_ {
+    pub use {
+        alloc::collections::TryReserveError, 
+        core::alloc::Allocator,
+        alloc::alloc::Global,
+    };
+    use std::ops::{Deref, DerefMut};
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct VecWrap<T, A: Allocator = Global>(alloc::vec::Vec<T, A>);
+
+    impl <T, A: Allocator> VecWrap<T, A> {
+        #[inline(always)] pub fn wrap(inner: alloc::vec::Vec<T, A>) -> Self { Self(inner) }
+        #[inline(always)] pub fn try_with_capacity_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> { Ok(Self::wrap(Vec::try_with_capacity_in(capacity, allocator)?)) }
+    }
+
+    impl <T, A: Allocator> Deref for VecWrap<T, A> {
+        type Target = alloc::vec::Vec<T, A>;
+        #[inline(always)] fn deref(&self) -> &Self::Target { &self.0 }
+    }
+
+    impl <T, A: Allocator> DerefMut for VecWrap<T, A> {
+        #[inline(always)] fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    }
+
+    impl <T, A: Allocator> IntoIterator for VecWrap<T, A> {
+        type Item = <<Self as Deref>::Target as IntoIterator>::Item;
+        type IntoIter = <<Self as Deref>::Target as IntoIterator>::IntoIter;
+        fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
+    }
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct VecIntoIterWrap<T, A: Allocator = Global>(alloc::vec::IntoIter<T, A>);
+    impl <T, A: Allocator> VecIntoIterWrap<T, A> {
+        #[inline(always)] pub fn wrap(inner: alloc::vec::IntoIter<T, A>) -> Self { Self(inner) }
+    }
+
+    impl <T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
+        type Item = <alloc::vec::IntoIter<T, A> as Iterator>::Item;
+        #[inline(always)] fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+    }
+
+}
+
+// If not on nightly, but allocator-api2 is enabled: use it
+#[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
+mod _impl_ {
+    pub use allocator_api2::{
+        vec::Vec as Vec,
+        collections::TryReserveError,
+        alloc::Allocator,
+        alloc::Global,
+    };
+    use std::ops::{Deref, DerefMut};
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct VecWrap<T, A: Allocator = Global>(allocator_api2::vec::Vec<T, A>);
+
+    impl <T, A: Allocator> VecWrap<T, A> {
+        #[inline(always)]
+        pub fn wrap(inner: allocator_api2::vec::Vec<T, A>) -> Self { Self(inner) }
+        #[inline(always)] 
+        pub fn try_with_capacity_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
+            // try_with_capacity_in is unstable, so we emulate it with a try_reserve when not on nightly
+            let mut vec = Vec::new_in(allocator);
+            vec.try_reserve(capacity)?;
+            Ok(VecWrap::wrap(vec))
+        }
+    }
+
+    impl <T, A: Allocator> Deref for VecWrap<T, A> {
+        type Target = allocator_api2::vec::Vec<T, A>;
+        #[inline(always)] fn deref(&self) -> &Self::Target { &self.0 }
+    }
+
+    impl <T, A: Allocator> DerefMut for VecWrap<T, A> {
+        #[inline(always)] fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    }
+
+    impl <T, A: Allocator> IntoIterator for VecWrap<T, A> {
+        type Item = <<Self as Deref>::Target as IntoIterator>::Item;
+        type IntoIter = <<Self as Deref>::Target as IntoIterator>::IntoIter;
+        fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
+    }
+
+    #[repr(transparent)]
+    #[derive(Debug, Clone)]
+    pub struct VecIntoIterWrap<T, A: Allocator = Global>(allocator_api2::vec::IntoIter<T, A>);
+    impl <T, A: Allocator> VecIntoIterWrap<T, A> {
+        #[inline(always)]
+        pub fn wrap(inner: allocator_api2::vec::IntoIter<T, A>) -> Self { Self(inner) }
+    }
+
+    impl <T, A: Allocator> Iterator for VecIntoIterWrap<T, A> {
+        type Item = <allocator_api2::vec::IntoIter<T, A> as Iterator>::Item;
+        #[inline(always)] fn next(&mut self) -> Option<Self::Item> { self.0.next() }
+    }
+
+}

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1,7 +1,5 @@
 //! Contains the slot map implementation.
 
-use alloc::collections::TryReserveError;
-use alloc::vec::Vec;
 use core::fmt;
 use core::iter::{Enumerate, FusedIterator};
 use core::marker::PhantomData;
@@ -10,6 +8,8 @@ use core::ops::{Index, IndexMut};
 
 use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
+
+use crate::alloc_impl::*;
 
 // Storage inside a slot or metadata for the freelist when vacant.
 union SlotUnion<T> {
@@ -126,14 +126,14 @@ impl<T: fmt::Debug> fmt::Debug for Slot<T> {
 ///
 /// See [crate documentation](crate) for more details.
 #[derive(Debug)]
-pub struct SlotMap<K: Key, V> {
-    slots: Vec<Slot<V>>,
+pub struct SlotMap<K: Key, V, A: Allocator = Global> {
+    slots: VecWrap<Slot<V>, A>,
     free_head: u32,
     num_elems: u32,
     _k: PhantomData<fn(K) -> K>,
 }
 
-impl<V> SlotMap<DefaultKey, V> {
+impl <V> SlotMap<DefaultKey, V, Global> {
     /// Constructs a new, empty [`SlotMap`].
     ///
     /// # Examples
@@ -162,7 +162,7 @@ impl<V> SlotMap<DefaultKey, V> {
     }
 }
 
-impl<K: Key, V> SlotMap<K, V> {
+impl <K: Key, V> SlotMap<K, V, Global> {
     /// Constructs a new, empty [`SlotMap`] with a custom key type.
     ///
     /// # Examples
@@ -201,7 +201,7 @@ impl<K: Key, V> SlotMap<K, V> {
         // We don't actually use the sentinel for anything currently, but
         // HopSlotMap does, and if we want keys to remain valid through
         // conversion we have to have one as well.
-        let mut slots = Vec::with_capacity(capacity + 1);
+        let mut slots = VecWrap::wrap(Vec::with_capacity(capacity + 1));
         slots.push(Slot {
             u: SlotUnion { next_free: 0 },
             version: 0,
@@ -213,6 +213,89 @@ impl<K: Key, V> SlotMap<K, V> {
             num_elems: 0,
             _k: PhantomData,
         }
+    }
+}
+
+impl <V, A: Allocator> SlotMap<DefaultKey, V, A> {
+    /// Constructs a new, empty [`SlotMap`] in the given Allocator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm: SlotMap<_, i32> = SlotMap::new_in(alloc::alloc::Global).expect("Failed to reserve initial memory");
+    /// ```
+    pub fn new_in(allocator: A) -> Result<Self, TryReserveError> {
+        Self::with_capacity_and_key_in(0, allocator)
+    }
+    /// Creates an empty [`SlotMap`] with the given capacity in the given Allocator.
+    ///
+    /// The slot map will not reallocate until it holds at least `capacity`
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// let mut sm: SlotMap<_, i32> = SlotMap::with_capacity_in(10, alloc::alloc::Global).expect("Failed to reserve initial memory");
+    /// ```
+    pub fn with_capacity_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
+        Self::with_capacity_and_key_in(capacity, allocator)
+    }
+}
+
+impl<K: Key, V, A: Allocator> SlotMap<K, V, A> {
+    
+    /// Constructs a new, empty [`SlotMap`] with a custom key type in the given Allocator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// new_key_type! {
+    ///     struct PositionKey;
+    /// }
+    /// let mut positions: SlotMap<PositionKey, i32> = SlotMap::with_key_in(alloc::alloc::Global).expect("Failed to reserve initial memory");
+    /// ```
+    pub fn with_key_in(allocator: A) -> Result<Self, TryReserveError> {
+        Self::with_capacity_and_key_in(0, allocator)
+    }
+
+    /// Creates an empty [`SlotMap`] with the given capacity and a custom key
+    /// type inside the given Allocator.
+    ///
+    /// The slot map will not reallocate until it holds at least `capacity`
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slotmap::*;
+    /// new_key_type! {
+    ///     struct MessageKey;
+    /// }
+    /// let mut messages = SlotMap::with_capacity_and_key_in(3, alloc::alloc::Global).expect("Failed to reserve initial memory");
+    /// let welcome: MessageKey = messages.insert("Welcome");
+    /// let good_day = messages.insert("Good day");
+    /// let hello = messages.insert("Hello");
+    /// ```
+    pub fn with_capacity_and_key_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
+        // Create slots with a sentinel at index 0.
+        // We don't actually use the sentinel for anything currently, but
+        // HopSlotMap does, and if we want keys to remain valid through
+        // conversion we have to have one as well.
+        let mut slots = VecWrap::try_with_capacity_in(capacity + 1, allocator)?;
+        slots.push(Slot {
+            u: SlotUnion { next_free: 0 },
+            version: 0,
+        });
+
+        Ok(Self {
+            slots,
+            free_head: 1,
+            num_elems: 0,
+            _k: PhantomData,
+        })
     }
 
     /// Returns the number of elements in the slot map.
@@ -681,7 +764,7 @@ impl<K: Key, V> SlotMap<K, V> {
     /// assert_eq!(sm.len(), 0);
     /// assert_eq!(v, vec![(k, 0)]);
     /// ```
-    pub fn drain(&mut self) -> Drain<'_, K, V> {
+    pub fn drain(&mut self) -> Drain<'_, K, V, A> {
         Drain { cur: 1, sm: self }
     }
 
@@ -1008,9 +1091,9 @@ impl<K: Key, V> SlotMap<K, V> {
     }
 }
 
-impl<K: Key, V> Clone for SlotMap<K, V>
+impl<K: Key, V, A: Allocator> Clone for SlotMap<K, V, A>
 where
-    V: Clone,
+    V: Clone, A: Clone
 {
     fn clone(&self) -> Self {
         Self {
@@ -1030,13 +1113,13 @@ where
     }
 }
 
-impl<K: Key, V> Default for SlotMap<K, V> {
+impl<K: Key, V> Default for SlotMap<K, V, Global> {
     fn default() -> Self {
         Self::with_key()
     }
 }
 
-impl<K: Key, V> Index<K> for SlotMap<K, V> {
+impl<K: Key, V, A: Allocator> Index<K> for SlotMap<K, V, A> {
     type Output = V;
 
     fn index(&self, key: K) -> &V {
@@ -1047,7 +1130,7 @@ impl<K: Key, V> Index<K> for SlotMap<K, V> {
     }
 }
 
-impl<K: Key, V> IndexMut<K> for SlotMap<K, V> {
+impl<K: Key, V, A: Allocator> IndexMut<K> for SlotMap<K, V, A> {
     fn index_mut(&mut self, key: K) -> &mut V {
         match self.get_mut(key) {
             Some(r) => r,
@@ -1061,8 +1144,8 @@ impl<K: Key, V> IndexMut<K> for SlotMap<K, V> {
 ///
 /// This iterator is created by [`SlotMap::drain`].
 #[derive(Debug)]
-pub struct Drain<'a, K: 'a + Key, V: 'a> {
-    sm: &'a mut SlotMap<K, V>,
+pub struct Drain<'a, K: 'a + Key, V: 'a, A: Allocator + 'a = Global> {
+    sm: &'a mut SlotMap<K, V, A>,
     cur: usize,
 }
 
@@ -1071,9 +1154,9 @@ pub struct Drain<'a, K: 'a + Key, V: 'a> {
 /// This iterator is created by calling the `into_iter` method on [`SlotMap`],
 /// provided by the [`IntoIterator`] trait.
 #[derive(Debug, Clone)]
-pub struct IntoIter<K: Key, V> {
+pub struct IntoIter<K: Key, V, A: Allocator = Global> {
     num_left: usize,
-    slots: Enumerate<alloc::vec::IntoIter<Slot<V>>>,
+    slots: Enumerate<VecIntoIterWrap<Slot<V>, A>>,
     _k: PhantomData<fn(K) -> K>,
 }
 
@@ -1147,7 +1230,7 @@ pub struct ValuesMut<'a, K: 'a + Key, V: 'a> {
     inner: IterMut<'a, K, V>,
 }
 
-impl<'a, K: Key, V> Iterator for Drain<'a, K, V> {
+impl<'a, K: Key, V, A: Allocator> Iterator for Drain<'a, K, V, A> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<(K, V)> {
@@ -1174,13 +1257,13 @@ impl<'a, K: Key, V> Iterator for Drain<'a, K, V> {
     }
 }
 
-impl<'a, K: Key, V> Drop for Drain<'a, K, V> {
+impl<'a, K: Key, V, A: Allocator> Drop for Drain<'a, K, V, A> {
     fn drop(&mut self) {
         self.for_each(|_drop| {});
     }
 }
 
-impl<K: Key, V> Iterator for IntoIter<K, V> {
+impl<K: Key, V, A: Allocator> Iterator for IntoIter<K, V, A> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<(K, V)> {
@@ -1284,7 +1367,7 @@ impl<'a, K: Key, V> Iterator for ValuesMut<'a, K, V> {
     }
 }
 
-impl<'a, K: Key, V> IntoIterator for &'a SlotMap<K, V> {
+impl<'a, K: Key, V, A: Allocator> IntoIterator for &'a SlotMap<K, V, A> {
     type Item = (K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
@@ -1293,7 +1376,7 @@ impl<'a, K: Key, V> IntoIterator for &'a SlotMap<K, V> {
     }
 }
 
-impl<'a, K: Key, V> IntoIterator for &'a mut SlotMap<K, V> {
+impl<'a, K: Key, V, A: Allocator> IntoIterator for &'a mut SlotMap<K, V, A> {
     type Item = (K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
@@ -1302,13 +1385,13 @@ impl<'a, K: Key, V> IntoIterator for &'a mut SlotMap<K, V> {
     }
 }
 
-impl<K: Key, V> IntoIterator for SlotMap<K, V> {
+impl<K: Key, V, A: Allocator> IntoIterator for SlotMap<K, V, A> {
     type Item = (K, V);
-    type IntoIter = IntoIter<K, V>;
+    type IntoIter = IntoIter<K, V, A>;
 
     fn into_iter(self) -> Self::IntoIter {
         let len = self.len();
-        let mut it = self.slots.into_iter().enumerate();
+        let mut it = VecIntoIterWrap::wrap(self.slots.into_iter()).enumerate();
         it.next(); // Skip sentinel.
         IntoIter {
             num_left: len,
@@ -1323,16 +1406,16 @@ impl<'a, K: Key, V> FusedIterator for IterMut<'a, K, V> {}
 impl<'a, K: Key, V> FusedIterator for Keys<'a, K, V> {}
 impl<'a, K: Key, V> FusedIterator for Values<'a, K, V> {}
 impl<'a, K: Key, V> FusedIterator for ValuesMut<'a, K, V> {}
-impl<'a, K: Key, V> FusedIterator for Drain<'a, K, V> {}
-impl<K: Key, V> FusedIterator for IntoIter<K, V> {}
+impl<'a, K: Key, V, A: Allocator> FusedIterator for Drain<'a, K, V, A> {}
+impl<K: Key, V, A: Allocator> FusedIterator for IntoIter<K, V, A> {}
 
 impl<'a, K: Key, V> ExactSizeIterator for Iter<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for IterMut<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for Keys<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for Values<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for ValuesMut<'a, K, V> {}
-impl<'a, K: Key, V> ExactSizeIterator for Drain<'a, K, V> {}
-impl<K: Key, V> ExactSizeIterator for IntoIter<K, V> {}
+impl<'a, K: Key, V, A: Allocator> ExactSizeIterator for Drain<'a, K, V, A> {}
+impl<K: Key, V, A: Allocator> ExactSizeIterator for IntoIter<K, V, A> {}
 
 // Serialization with serde.
 #[cfg(feature = "serde")]
@@ -1539,7 +1622,7 @@ mod tests {
     }
 
     quickcheck! {
-        fn qc_slotmap_equiv_hashmap(operations: Vec<(u8, u32)>) -> bool {
+        fn qc_slotmap_equiv_hashmap(operations: alloc::vec::Vec<(u8, u32)>) -> bool {
             let mut hm = HashMap::new();
             let mut hm_keys = Vec::new();
             let mut unique_key = 0u32;

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -6,10 +6,9 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
 
+use crate::alloc_impl::*;
 use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
-
-use crate::alloc_impl::*;
 
 // Storage inside a slot or metadata for the freelist when vacant.
 union SlotUnion<T> {
@@ -133,7 +132,7 @@ pub struct SlotMap<K: Key, V, A: Allocator = Global> {
     _k: PhantomData<fn(K) -> K>,
 }
 
-impl <V> SlotMap<DefaultKey, V, Global> {
+impl<V> SlotMap<DefaultKey, V, Global> {
     /// Constructs a new, empty [`SlotMap`].
     ///
     /// # Examples
@@ -162,7 +161,7 @@ impl <V> SlotMap<DefaultKey, V, Global> {
     }
 }
 
-impl <K: Key, V> SlotMap<K, V, Global> {
+impl<K: Key, V> SlotMap<K, V, Global> {
     /// Constructs a new, empty [`SlotMap`] with a custom key type.
     ///
     /// # Examples
@@ -216,7 +215,7 @@ impl <K: Key, V> SlotMap<K, V, Global> {
     }
 }
 
-impl <V, A: Allocator> SlotMap<DefaultKey, V, A> {
+impl<V, A: Allocator> SlotMap<DefaultKey, V, A> {
     /// Constructs a new, empty [`SlotMap`] in the given Allocator.
     pub fn new_in(allocator: A) -> Result<Self, TryReserveError> {
         Self::with_capacity_and_key_in(0, allocator)
@@ -231,7 +230,6 @@ impl <V, A: Allocator> SlotMap<DefaultKey, V, A> {
 }
 
 impl<K: Key, V, A: Allocator> SlotMap<K, V, A> {
-    
     /// Constructs a new, empty [`SlotMap`] with a custom key type in the given Allocator.
     pub fn with_key_in(allocator: A) -> Result<Self, TryReserveError> {
         Self::with_capacity_and_key_in(0, allocator)
@@ -242,7 +240,10 @@ impl<K: Key, V, A: Allocator> SlotMap<K, V, A> {
     ///
     /// The slot map will not reallocate until it holds at least `capacity`
     /// elements.
-    pub fn with_capacity_and_key_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
+    pub fn with_capacity_and_key_in(
+        capacity: usize,
+        allocator: A,
+    ) -> Result<Self, TryReserveError> {
         // Create slots with a sentinel at index 0.
         // We don't actually use the sentinel for anything currently, but
         // HopSlotMap does, and if we want keys to remain valid through
@@ -1056,7 +1057,8 @@ impl<K: Key, V, A: Allocator> SlotMap<K, V, A> {
 
 impl<K: Key, V, A: Allocator> Clone for SlotMap<K, V, A>
 where
-    V: Clone, A: Clone
+    V: Clone,
+    A: Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -1592,26 +1594,36 @@ mod tests {
         use core::sync::atomic::{AtomicUsize, Ordering};
 
         struct TestAlloc {
-            allocated_bytes: AtomicUsize
+            allocated_bytes: AtomicUsize,
         }
         unsafe impl Allocator for TestAlloc {
-            fn allocate(&self, layout: core::alloc::Layout) -> Result<core::ptr::NonNull<[u8]>, AllocError> {
-                self.allocated_bytes.fetch_add(layout.size(), Ordering::AcqRel);
+            fn allocate(
+                &self,
+                layout: core::alloc::Layout,
+            ) -> Result<core::ptr::NonNull<[u8]>, AllocError> {
+                self.allocated_bytes
+                    .fetch_add(layout.size(), Ordering::AcqRel);
                 Global.allocate(layout)
             }
             unsafe fn deallocate(&self, ptr: core::ptr::NonNull<u8>, layout: core::alloc::Layout) {
-                self.allocated_bytes.fetch_sub(layout.size(), Ordering::AcqRel);
+                self.allocated_bytes
+                    .fetch_sub(layout.size(), Ordering::AcqRel);
                 Global.deallocate(ptr, layout);
             }
         }
 
-        let alloc = TestAlloc { allocated_bytes: AtomicUsize::new(0) };
+        let alloc = TestAlloc {
+            allocated_bytes: AtomicUsize::new(0),
+        };
 
-        let mut sm: SlotMap<DefaultKey, usize, &TestAlloc> = SlotMap::new_in(&alloc).expect("Failed to allocate initial map");
+        let mut sm: SlotMap<DefaultKey, usize, &TestAlloc> =
+            SlotMap::new_in(&alloc).expect("Failed to allocate initial map");
         // Ensure initial allocation is tracked
         assert!(alloc.allocated_bytes.load(Ordering::Acquire) > 0);
         // Ensure tracked allocation is big enough and makes sense with how many things we inserted
-        for i in 0..1000 { sm.insert(i * i); }
+        for i in 0..1000 {
+            sm.insert(i * i);
+        }
         assert!(alloc.allocated_bytes.load(Ordering::Acquire) > 1000 * size_of::<usize>());
         // Ensure that when we drop, everything is freed using the allocator
         drop(sm);

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -218,13 +218,6 @@ impl <K: Key, V> SlotMap<K, V, Global> {
 
 impl <V, A: Allocator> SlotMap<DefaultKey, V, A> {
     /// Constructs a new, empty [`SlotMap`] in the given Allocator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slotmap::*;
-    /// let mut sm: SlotMap<_, i32> = SlotMap::new_in(alloc::alloc::Global).expect("Failed to reserve initial memory");
-    /// ```
     pub fn new_in(allocator: A) -> Result<Self, TryReserveError> {
         Self::with_capacity_and_key_in(0, allocator)
     }
@@ -232,13 +225,6 @@ impl <V, A: Allocator> SlotMap<DefaultKey, V, A> {
     ///
     /// The slot map will not reallocate until it holds at least `capacity`
     /// elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slotmap::*;
-    /// let mut sm: SlotMap<_, i32> = SlotMap::with_capacity_in(10, alloc::alloc::Global).expect("Failed to reserve initial memory");
-    /// ```
     pub fn with_capacity_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
         Self::with_capacity_and_key_in(capacity, allocator)
     }
@@ -247,16 +233,6 @@ impl <V, A: Allocator> SlotMap<DefaultKey, V, A> {
 impl<K: Key, V, A: Allocator> SlotMap<K, V, A> {
     
     /// Constructs a new, empty [`SlotMap`] with a custom key type in the given Allocator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slotmap::*;
-    /// new_key_type! {
-    ///     struct PositionKey;
-    /// }
-    /// let mut positions: SlotMap<PositionKey, i32> = SlotMap::with_key_in(alloc::alloc::Global).expect("Failed to reserve initial memory");
-    /// ```
     pub fn with_key_in(allocator: A) -> Result<Self, TryReserveError> {
         Self::with_capacity_and_key_in(0, allocator)
     }
@@ -266,19 +242,6 @@ impl<K: Key, V, A: Allocator> SlotMap<K, V, A> {
     ///
     /// The slot map will not reallocate until it holds at least `capacity`
     /// elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slotmap::*;
-    /// new_key_type! {
-    ///     struct MessageKey;
-    /// }
-    /// let mut messages = SlotMap::with_capacity_and_key_in(3, alloc::alloc::Global).expect("Failed to reserve initial memory");
-    /// let welcome: MessageKey = messages.insert("Welcome");
-    /// let good_day = messages.insert("Good day");
-    /// let hello = messages.insert("Hello");
-    /// ```
     pub fn with_capacity_and_key_in(capacity: usize, allocator: A) -> Result<Self, TryReserveError> {
         // Create slots with a sentinel at index 0.
         // We don't actually use the sentinel for anything currently, but

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1435,7 +1435,7 @@ mod serialize {
         }
     }
 
-    impl<K: Key, V: Serialize> Serialize for SlotMap<K, V> {
+    impl<K: Key, V: Serialize, A: Allocator> Serialize for SlotMap<K, V, A> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -1453,7 +1453,9 @@ mod serialize {
         where
             D: Deserializer<'de>,
         {
-            let mut slots: Vec<Slot<V>> = Deserialize::deserialize(deserializer)?;
+            let slots: Vec<Slot<V>> = Deserialize::deserialize(deserializer)?;
+            let mut slots = VecWrap::wrap(slots);
+
             if slots.len() >= u32::MAX as usize {
                 return Err(de::Error::custom("too many slots"));
             }

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1584,6 +1584,38 @@ mod tests {
         }
     }
 
+    #[cfg(any(feature = "nightly", feature = "allocator-api2"))]
+    #[test]
+    fn custom_allocator() {
+        use core::sync::atomic::{AtomicUsize, Ordering};
+
+        struct TestAlloc {
+            allocated_bytes: AtomicUsize
+        }
+        unsafe impl Allocator for TestAlloc {
+            fn allocate(&self, layout: core::alloc::Layout) -> Result<core::ptr::NonNull<[u8]>, AllocError> {
+                self.allocated_bytes.fetch_add(layout.size(), Ordering::AcqRel);
+                Global.allocate(layout)
+            }
+            unsafe fn deallocate(&self, ptr: core::ptr::NonNull<u8>, layout: core::alloc::Layout) {
+                self.allocated_bytes.fetch_sub(layout.size(), Ordering::AcqRel);
+                Global.deallocate(ptr, layout);
+            }
+        }
+
+        let alloc = TestAlloc { allocated_bytes: AtomicUsize::new(0) };
+
+        let mut sm: SlotMap<DefaultKey, usize, &TestAlloc> = SlotMap::new_in(&alloc).expect("Failed to allocate initial map");
+        // Ensure initial allocation is tracked
+        assert!(alloc.allocated_bytes.load(Ordering::Acquire) > 0);
+        // Ensure tracked allocation is big enough and makes sense with how many things we inserted
+        for i in 0..1000 { sm.insert(i * i); }
+        assert!(alloc.allocated_bytes.load(Ordering::Acquire) > 1000 * size_of::<usize>());
+        // Ensure that when we drop, everything is freed using the allocator
+        drop(sm);
+        assert!(alloc.allocated_bytes.load(Ordering::Acquire) == 0);
+    }
+
     quickcheck! {
         fn qc_slotmap_equiv_hashmap(operations: alloc::vec::Vec<(u8, u32)>) -> bool {
             let mut hm = HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![crate_name = "slotmap"]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(all(nightly, doc), feature(doc_cfg))]
+#![cfg_attr(all(feature = "nightly"), feature(allocator_api))]
 #![warn(
     missing_debug_implementations,
     trivial_casts,
@@ -199,6 +200,7 @@ pub mod __impl {
     pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
 }
 
+pub(crate) mod alloc_impl;
 pub mod basic;
 pub mod dense;
 pub mod hop;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,8 @@ pub mod hop;
 pub mod secondary;
 #[cfg(feature = "std")]
 pub mod sparse_secondary;
+#[cfg(all(test, not(feature = "std")))]
+mod sparse_secondary; // If we're testing without std, we still want access to SparseSecondaryMap so tests using it can compile
 pub(crate) mod util;
 
 use core::fmt::{self, Debug, Formatter};
@@ -595,6 +597,7 @@ mod tests {
 
     #[test]
     fn iters_cloneable() {
+        use super::sparse_secondary::SparseSecondaryMap;
         use super::*;
 
         struct NoClone;

--- a/src/sparse_secondary.rs
+++ b/src/sparse_secondary.rs
@@ -1613,6 +1613,7 @@ mod tests {
 
     use quickcheck::quickcheck;
 
+    use crate::sparse_secondary::SparseSecondaryMap;
     use crate::*;
 
     #[test]


### PR DESCRIPTION
Allows the basic `SlotMap` type to take an extra `A: Allocator` generic which will be used for allocation. There are 3 modes depending on the features selected:
- Default features: Same as the current impl. The A: Allocator is just a dummy type which does nothing, and the real impl uses the same alloc::vec::Vec as currently.
- `nightly` feature: Uses the nightly allocator API Allocator trait
- `allocator-api2` feature: Uses the allocator-api2 crate to implement the allocator api in stable Rust, without needing nightly

Currently the impl only targets the `SlotMap` type defined in `basic.rs`, but it could be implemented for the other maps similarly.

Please let me know if you have questions about my impl or suggestions for things that should change. Thanks!

Edit: I heard that apparently there's movement happening recently towards stabilizing allocator API. If that happens, this PR would be essentially useless, since most of its functionality is in switching allocator impls between feature sets. So if you believe it'll be stable soon, then it would be better to ignore/close this PR, and use the API in a normal, sane way without the weird config/modules/newtype hacks.