### PR TITLE
Rayon support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,116 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
+name = "arrayvec"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
+dependencies = [
+ "crossbeam-epoch 0.7.2",
+ "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch 0.9.18",
+ "crossbeam-utils 0.8.21",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
+dependencies = [
+ "arrayvec",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.6.6",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils 0.8.21",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_logger"
@@ -44,56 +136,101 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quickcheck"
-version = "1.0.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+checksum = "70c7509d6bdc8297b37f3bc369ca249bfe53cecc6b085b82ba538e4fb4e8f8e6"
 dependencies = [
  "env_logger",
  "log",
@@ -102,36 +239,87 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.4"
+name = "rayon"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "a4b0186e22767d5b9738a05eab7c6ac90b15db17e5b5f9bd87976dd7d89a10a4"
+dependencies = [
+ "crossbeam-deque 0.6.3",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque 0.8.6",
+ "crossbeam-utils 0.8.21",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -140,44 +328,55 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "ryu"
-version = "1.0.9"
+name = "scopeguard"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "369633cfe0f0bde1dfc037fb6c5a329d46586a31f981bed14d87487a3439ae37"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "6a61ecb8511aaff381424f98b49a059017420ec60e15e8d63b645701af7fa9b8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "quote 0.3.15",
+ "serde_derive_internals",
+ "syn 0.11.11",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
+dependencies = [
+ "syn 0.11.11",
+ "synom",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "e9b1ec939469a124b27e208106550c38358ed4334d2b1b5b3825bc1ee37d946a"
 dependencies = [
+ "dtoa",
  "itoa",
- "ryu",
+ "num-traits 0.1.43",
  "serde",
 ]
 
@@ -187,6 +386,7 @@ version = "1.1.1"
 dependencies = [
  "fxhash",
  "quickcheck",
+ "rayon",
  "serde",
  "serde_derive",
  "serde_json",
@@ -195,29 +395,75 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 dependencies = [
- "proc-macro2",
- "quote",
+ "quote 0.3.15",
+ "synom",
  "unicode-xid",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "syn"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "45d3d553fd9413fffe7147a20171d640eda0ad4c070acd7d0c885a21bcd2e8b7"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,16 @@ repository = "https://github.com/orlp/slotmap"
 readme = "README.md"
 keywords = ["slotmap", "storage", "allocator", "arena", "reference"]
 categories = ["data-structures", "memory-management", "caching"]
-rust-version = "1.58.0"
+rust-version = "1.60.0"
 
 [features]
 default = ["std"]
 unstable = []
 std = []
+rayon = ["std", "dep:rayon"]
 
 [dependencies]
+rayon = { version = "1.1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ownership otherwise, such as game entities or graph nodes. Two secondary maps,
 further objects to the keys created by one of the slot maps. Please refer to
 [**the documentation**](https://docs.rs/slotmap) for more information.
 
-The minimum required stable Rust version for `slotmap` is 1.58. To start using
+The minimum required stable Rust version for `slotmap` is 1.60. To start using
 `slotmap` add the following to your `Cargo.toml`:
 
 ```toml

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -8,6 +8,9 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Index, IndexMut};
 
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
 use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
 
@@ -1006,6 +1009,89 @@ impl<K: Key, V> SlotMap<K, V> {
             inner: self.iter_mut(),
         }
     }
+
+    /// A parallel iterator visiting all key-value pairs in an arbitrary order.
+    /// The iterator element type is `(K, &'a V)`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter(&self) -> ParIter<'_, K, V>
+    where
+        K: Send,
+        V: Sync,
+    {
+        ParIter {
+            slots: self.slots.par_iter().enumerate(),
+            _k: PhantomData,
+        }
+    }
+
+    /// A parallel iterator visiting all key-value pairs in an arbitrary order,
+    /// with mutable references to the values. The iterator element type is
+    /// `(K, &'a mut V)`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter_mut(&mut self) -> ParIterMut<'_, K, V>
+    where
+        K: Send,
+        V: Send,
+    {
+        ParIterMut {
+            slots: self.slots.par_iter_mut().enumerate(),
+            _k: PhantomData,
+        }
+    }
+
+    /// A parallel iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is `K`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_keys(&self) -> ParKeys<'_, K, V>
+    where
+        K: Send,
+        V: Sync,
+    {
+        ParKeys {
+            inner: self.par_iter(),
+        }
+    }
+
+    /// A parallel iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_values(&self) -> ParValues<'_, K, V>
+    where
+        K: Send,
+        V: Sync,
+    {
+        ParValues {
+            inner: self.par_iter(),
+        }
+    }
+
+    /// A parallel iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_values_mut(&mut self) -> ParValuesMut<'_, K, V>
+    where
+        K: Send,
+        V: Send,
+    {
+        ParValuesMut {
+            inner: self.par_iter_mut(),
+        }
+    }
 }
 
 impl<K: Key, V> Clone for SlotMap<K, V>
@@ -1333,6 +1419,262 @@ impl<'a, K: Key, V> ExactSizeIterator for Values<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for ValuesMut<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for Drain<'a, K, V> {}
 impl<K: Key, V> ExactSizeIterator for IntoIter<K, V> {}
+
+/// A parallel iterator over the key-value pairs in a [`SlotMap`].
+///
+/// This iterator is created by [`SlotMap::par_iter`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParIter<'a, K: 'a + Key, V: 'a> {
+    slots: rayon::iter::Enumerate<rayon::slice::Iter<'a, Slot<V>>>,
+    _k: PhantomData<fn(K) -> K>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParIter<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParIter {
+            slots: self.slots.clone(),
+            _k: self._k,
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParIter<'a, K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = (K, &'a V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.slots
+            .filter_map(|(idx, slot)| {
+                if let Occupied(value) = slot.get() {
+                    Some((KeyData::new(idx as u32, slot.version).into(), value))
+                } else {
+                    None
+                }
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+/// A parallel mutable iterator over the key-value pairs in a [`SlotMap`].
+///
+/// This iterator is created by [`SlotMap::par_iter_mut`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParIterMut<'a, K: 'a + Key, V: 'a> {
+    slots: rayon::iter::Enumerate<rayon::slice::IterMut<'a, Slot<V>>>,
+    _k: PhantomData<fn(K) -> K>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParIterMut<'a, K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, &'a mut V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.slots
+            .filter_map(|(idx, slot)| {
+                let version = slot.version;
+                if let OccupiedMut(value) = slot.get_mut() {
+                    Some((KeyData::new(idx as u32, version).into(), value))
+                } else {
+                    None
+                }
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+/// A parallel iterator that moves key-value pairs out of a [`SlotMap`].
+///
+/// This iterator is created by calling the `into_par_iter` method on [`SlotMap`],
+/// provided by the [`IntoParallelIterator`] trait.
+#[cfg(feature = "rayon")]
+#[derive(Debug, Clone)]
+pub struct IntoParIter<K: Key, V> {
+    slots: rayon::iter::Enumerate<rayon::vec::IntoIter<Slot<V>>>,
+    _k: PhantomData<fn(K) -> K>,
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> ParallelIterator for IntoParIter<K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.slots
+            .filter_map(|(idx, mut slot)| {
+                if !slot.occupied() {
+                    return None;
+                }
+
+                let key = KeyData::new(idx as u32, slot.version).into();
+                slot.version = 0;
+                // As with IntoIter, this is safe because we know the slot was occupied.
+                let value = unsafe { ManuallyDrop::take(&mut slot.u.value) };
+                Some((key, value))
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IntoParallelIterator for &'a SlotMap<K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = (K, &'a V);
+    type Iter = ParIter<'a, K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IntoParallelIterator for &'a mut SlotMap<K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, &'a mut V);
+    type Iter = ParIterMut<'a, K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter_mut()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> IntoParallelIterator for SlotMap<K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, V);
+    type Iter = IntoParIter<K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        IntoParIter {
+            slots: self.slots.into_par_iter().enumerate(),
+            _k: PhantomData,
+        }
+    }
+}
+
+/// A parallel iterator over the keys in a [`SlotMap`].
+///
+/// This iterator is created by [`SlotMap::par_keys`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParKeys<'a, K: 'a + Key, V: 'a> {
+    inner: ParIter<'a, K, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParKeys<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParKeys {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParKeys<'a, K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = K;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(key, _)| key).drive_unindexed(consumer)
+    }
+}
+
+/// A parallel iterator over the values in a [`SlotMap`].
+///
+/// This iterator is created by [`SlotMap::par_values`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParValues<'a, K: 'a + Key, V: 'a> {
+    inner: ParIter<'a, K, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParValues<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParValues {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParValues<'a, K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = &'a V;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(_, value)| value).drive_unindexed(consumer)
+    }
+}
+
+/// A parallel mutable iterator over the values in a [`SlotMap`].
+///
+/// This iterator is created by [`SlotMap::par_values_mut`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParValuesMut<'a, K: 'a + Key, V: 'a> {
+    inner: ParIterMut<'a, K, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParValuesMut<'a, K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = &'a mut V;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(_, value)| value).drive_unindexed(consumer)
+    }
+}
 
 // Serialization with serde.
 #[cfg(feature = "serde")]

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -12,6 +12,9 @@ use core::iter::FusedIterator;
 use core::mem::MaybeUninit;
 use core::ops::{Index, IndexMut};
 
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
 use crate::util::{Never, PanicOnDrop, UnwrapNever};
 use crate::{DefaultKey, Key, KeyData};
 
@@ -1025,6 +1028,69 @@ impl<K: Key, V> DenseSlotMap<K, V> {
     pub fn as_mut_slices(&mut self) -> (&[K], &mut [V]) {
         (self.keys.as_slice(), self.values.as_mut_slice())
     }
+
+    /// A parallel iterator visiting all key-value pairs in an arbitrary order. The
+    /// iterator element type is `(K, &'a V)`.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter(&self) -> ParIter<'_, K, V>
+    where
+        K: Send + Sync,
+        V: Sync,
+    {
+        ParIter {
+            inner: self.keys.par_iter().copied().zip(self.values.par_iter()),
+        }
+    }
+
+    /// A parallel iterator visiting all key-value pairs in an arbitrary order, with
+    /// mutable references to the values. The iterator element type is
+    /// `(K, &'a mut V)`.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter_mut(&mut self) -> ParIterMut<'_, K, V>
+    where
+        K: Send + Sync,
+        V: Send,
+    {
+        ParIterMut {
+            inner: self.keys.par_iter().copied().zip(self.values.par_iter_mut()),
+        }
+    }
+
+    /// A parallel iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is K.
+    #[cfg(feature = "rayon")]
+    pub fn par_keys(&self) -> ParKeys<'_, K>
+    where
+        K: Send + Sync,
+    {
+        ParKeys {
+            inner: self.keys.par_iter().copied(),
+        }
+    }
+
+    /// A parallel iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
+    #[cfg(feature = "rayon")]
+    pub fn par_values(&self) -> ParValues<'_, V>
+    where
+        V: Sync,
+    {
+        ParValues {
+            inner: self.values.par_iter(),
+        }
+    }
+
+    /// A parallel iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
+    #[cfg(feature = "rayon")]
+    pub fn par_values_mut(&mut self) -> ParValuesMut<'_, V>
+    where
+        V: Send,
+    {
+        ParValuesMut {
+            inner: self.values.par_iter_mut(),
+        }
+    }
 }
 
 impl<K: Key, V> Clone for DenseSlotMap<K, V>
@@ -1330,6 +1396,381 @@ impl<'a, K: 'a + Key, V> ExactSizeIterator for Values<'a, K, V> {}
 impl<'a, K: 'a + Key, V> ExactSizeIterator for ValuesMut<'a, K, V> {}
 impl<'a, K: 'a + Key, V> ExactSizeIterator for Drain<'a, K, V> {}
 impl<K: Key, V> ExactSizeIterator for IntoIter<K, V> {}
+
+/// A parallel iterator over the key-value pairs in a [`DenseSlotMap`].
+///
+/// This iterator is created by [`DenseSlotMap::par_iter`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParIter<'a, K: 'a + Key, V: 'a> {
+    inner: rayon::iter::Zip<
+        rayon::iter::Copied<rayon::slice::Iter<'a, K>>,
+        rayon::slice::Iter<'a, V>,
+    >,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParIter<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParIter {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParIter<'a, K, V>
+where
+    K: Key + Send + Sync,
+    V: Sync,
+{
+    type Item = (K, &'a V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.drive(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IndexedParallelIterator for ParIter<'a, K, V>
+where
+    K: Key + Send + Sync,
+    V: Sync,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.inner.drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.inner.with_producer(callback)
+    }
+}
+
+/// A parallel mutable iterator over the key-value pairs in a [`DenseSlotMap`].
+///
+/// This iterator is created by [`DenseSlotMap::par_iter_mut`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParIterMut<'a, K: 'a + Key, V: 'a> {
+    inner: rayon::iter::Zip<
+        rayon::iter::Copied<rayon::slice::Iter<'a, K>>,
+        rayon::slice::IterMut<'a, V>,
+    >,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParIterMut<'a, K, V>
+where
+    K: Key + Send + Sync,
+    V: Send,
+{
+    type Item = (K, &'a mut V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.drive(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IndexedParallelIterator for ParIterMut<'a, K, V>
+where
+    K: Key + Send + Sync,
+    V: Send,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.inner.drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.inner.with_producer(callback)
+    }
+}
+
+/// A parallel iterator over the keys in a [`DenseSlotMap`].
+///
+/// This iterator is created by [`DenseSlotMap::par_keys`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParKeys<'a, K: 'a + Key> {
+    inner: rayon::iter::Copied<rayon::slice::Iter<'a, K>>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key> Clone for ParKeys<'a, K> {
+    fn clone(&self) -> Self {
+        ParKeys {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K> ParallelIterator for ParKeys<'a, K>
+where
+    K: Key + Send + Sync,
+{
+    type Item = K;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.drive(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K> IndexedParallelIterator for ParKeys<'a, K>
+where
+    K: Key + Send + Sync,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.inner.drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.inner.with_producer(callback)
+    }
+}
+
+/// An iterator over the values in a [`DenseSlotMap`].
+///
+/// This iterator is created by [`DenseSlotMap::values`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParValues<'a, V: 'a> {
+    inner: rayon::slice::Iter<'a, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, V: 'a> Clone for ParValues<'a, V> {
+    fn clone(&self) -> Self {
+        ParValues {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, V> ParallelIterator for ParValues<'a, V>
+where
+    V: Sync,
+{
+    type Item = &'a V;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.drive(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, V> IndexedParallelIterator for ParValues<'a, V>
+where
+    V: Sync,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.inner.drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.inner.with_producer(callback)
+    }
+}
+
+/// A parallel mutable iterator over the values in a [`DenseSlotMap`].
+///
+/// This iterator is created by [`DenseSlotMap::par_values_mut`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParValuesMut<'a, V: 'a> {
+    inner: rayon::slice::IterMut<'a, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, V> ParallelIterator for ParValuesMut<'a, V>
+where
+    V: Send,
+{
+    type Item = &'a mut V;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.drive(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, V> IndexedParallelIterator for ParValuesMut<'a, V>
+where
+    V: Send,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.inner.drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.inner.with_producer(callback)
+    }
+}
+
+/// A parallel iterator that moves key-value pairs out of a [`DenseSlotMap`].
+///
+/// This iterator is created by calling the `into_par_iter` method on [`DenseSlotMap`],
+/// provided by the [`IntoParallelIterator`] trait.
+#[cfg(feature = "rayon")]
+#[derive(Debug, Clone)]
+pub struct IntoParIter<K, V> {
+    inner: rayon::iter::Zip<
+        rayon::vec::IntoIter<K>,
+        rayon::vec::IntoIter<V>,
+    >,
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> ParallelIterator for IntoParIter<K, V>
+where
+    K: Key + Send + Sync,
+    V: Send,
+{
+    type Item = (K, V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.drive(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> IndexedParallelIterator for IntoParIter<K, V>
+where
+    K: Key + Send + Sync,
+    V: Send,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.inner.drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.inner.with_producer(callback)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IntoParallelIterator for &'a DenseSlotMap<K, V>
+where
+    K: Key + Send + Sync,
+    V: Sync,
+{
+    type Item = (K, &'a V);
+    type Iter = ParIter<'a, K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IntoParallelIterator for &'a mut DenseSlotMap<K, V>
+where
+    K: Key + Send + Sync,
+    V: Send,
+{
+    type Item = (K, &'a mut V);
+    type Iter = ParIterMut<'a, K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter_mut()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> IntoParallelIterator for DenseSlotMap<K, V>
+where
+    K: Key + Send + Sync,
+    V: Send,
+{
+    type Item = (K, V);
+    type Iter = IntoParIter<K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        IntoParIter {
+            inner: self.keys.into_par_iter().zip(self.values.into_par_iter()),
+        }
+    }
+}
 
 // Serialization with serde.
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! }
 //! ```
 //!
-//! # Serialization through [`serde`], [`no_std`] support and unstable features
+//! # Serialization through [`serde`], [`rayon`], [`no_std`] support and unstable features
 //!
 //! Both keys and the slot maps have full (de)seralization support through
 //! the [`serde`] library. A key remains valid for a slot map even after one or
@@ -73,6 +73,13 @@
 //!
 //! ```text
 //! slotmap = { version = "1.0", features = ["serde"] }
+//! ```
+//!
+//! If you want parallel iteration support through [`rayon`], enable the
+//! `rayon` feature flag:
+//!
+//! ```text
+//! slotmap = { version = "1.0", features = ["rayon"] }
 //! ```
 //!
 //! This crate also supports [`no_std`] environments, but does require the
@@ -182,6 +189,7 @@
 //! [`Vec`]: std::vec::Vec
 //! [`BTreeMap`]: std::collections::BTreeMap
 //! [`HashMap`]: std::collections::HashMap
+//! [`rayon`]: https://github.com/rayon-rs/rayon
 //! [`serde`]: https://github.com/serde-rs/serde
 //! [`slab`]: https://crates.io/crates/slab
 //! [`stable-vec`]: https://crates.io/crates/stable-vec

--- a/src/secondary.rs
+++ b/src/secondary.rs
@@ -9,6 +9,9 @@ use core::mem::{replace, MaybeUninit};
 use core::num::NonZeroU32;
 use core::ops::{Index, IndexMut};
 
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
+
 use super::{Key, KeyData};
 use crate::util::is_older_version;
 
@@ -836,6 +839,89 @@ impl<K: Key, V> SecondaryMap<K, V> {
         }
     }
 
+    /// A parallel iterator visiting all key-value pairs in an arbitrary order. The
+    /// iterator element type is `(K, &'a V)`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter(&self) -> ParIter<'_, K, V>
+    where
+        K: Send,
+        V: Sync,
+    {
+        ParIter {
+            slots: self.slots.par_iter().enumerate(),
+            _k: PhantomData,
+        }
+    }
+
+    /// A parallel iterator visiting all key-value pairs in an arbitrary order, with
+    /// mutable references to the values. The iterator element type is
+    /// `(K, &'a mut V)`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter_mut(&mut self) -> ParIterMut<'_, K, V>
+    where
+        K: Send,
+        V: Send,
+    {
+        ParIterMut {
+            slots: self.slots.par_iter_mut().enumerate(),
+            _k: PhantomData,
+        }
+    }
+
+    /// A parallel iterator visiting all keys in an arbitrary order. The iterator
+    /// element type is `K`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_keys(&self) -> ParKeys<'_, K, V>
+    where
+        K: Send,
+        V: Sync,
+    {
+        ParKeys {
+            inner: self.par_iter(),
+        }
+    }
+
+    /// A parallel iterator visiting all values in an arbitrary order. The iterator
+    /// element type is `&'a V`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_values(&self) -> ParValues<'_, K, V>
+    where
+        K: Send,
+        V: Sync,
+    {
+        ParValues {
+            inner: self.par_iter(),
+        }
+    }
+
+    /// A parallel iterator visiting all values mutably in an arbitrary order. The
+    /// iterator element type is `&'a mut V`.
+    ///
+    /// This function must iterate over all slots, empty or not. In the face of
+    /// many deleted elements it can be inefficient.
+    #[cfg(feature = "rayon")]
+    pub fn par_values_mut(&mut self) -> ParValuesMut<'_, K, V>
+    where
+        K: Send,
+        V: Send,
+    {
+        ParValuesMut {
+            inner: self.par_iter_mut(),
+        }
+    }
+
     /// Gets the given key's corresponding [`Entry`] in the map for in-place
     /// manipulation. May return [`None`] if the key was removed from the
     /// originating slot map.
@@ -1582,6 +1668,260 @@ impl<'a, K: Key, V> ExactSizeIterator for Values<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for ValuesMut<'a, K, V> {}
 impl<'a, K: Key, V> ExactSizeIterator for Drain<'a, K, V> {}
 impl<K: Key, V> ExactSizeIterator for IntoIter<K, V> {}
+
+/// A parallel iterator over the key-value pairs in a [`SecondaryMap`].
+///
+/// This iterator is created by [`SecondaryMap::par_iter`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParIter<'a, K: 'a + Key, V: 'a> {
+    slots: rayon::iter::Enumerate<rayon::slice::Iter<'a, Slot<V>>>,
+    _k: PhantomData<fn(K) -> K>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParIter<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParIter {
+            slots: self.slots.clone(),
+            _k: self._k,
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParIter<'a, K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = (K, &'a V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.slots
+            .filter_map(|(idx, slot)| {
+                if let Occupied { value, version } = slot {
+                    let key = KeyData::new(idx as u32, version.get()).into();
+                    Some((key, value))
+                } else {
+                    None
+                }
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+/// A parallel mutable iterator over the key-value pairs in a [`SecondaryMap`].
+///
+/// This iterator is created by [`SecondaryMap::par_iter_mut`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParIterMut<'a, K: 'a + Key, V: 'a> {
+    slots: rayon::iter::Enumerate<rayon::slice::IterMut<'a, Slot<V>>>,
+    _k: PhantomData<fn(K) -> K>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParIterMut<'a, K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, &'a mut V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.slots
+            .filter_map(|(idx, slot)| {
+                if let Occupied { value, version } = slot {
+                    let key = KeyData::new(idx as u32, version.get()).into();
+                    Some((key, value))
+                } else {
+                    None
+                }
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+/// A parallel iterator that moves key-value pairs out of a [`SecondaryMap`].
+///
+/// This iterator is created by calling the `into_par_iter` method on [`SecondaryMap`],
+/// provided by the [`IntoParallelIterator`] trait.
+#[cfg(feature = "rayon")]
+#[derive(Debug, Clone)]
+pub struct IntoParIter<K: Key, V> {
+    slots: rayon::iter::Enumerate<rayon::vec::IntoIter<Slot<V>>>,
+    _k: PhantomData<fn(K) -> K>,
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> ParallelIterator for IntoParIter<K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, V);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.slots
+            .filter_map(|(idx, mut slot)| {
+                if let Occupied { value, version } = replace(&mut slot, Slot::new_vacant()) {
+                    let key = KeyData::new(idx as u32, version.get()).into();
+                    Some((key, value))
+                } else {
+                    None
+                }
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IntoParallelIterator for &'a SecondaryMap<K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = (K, &'a V);
+    type Iter = ParIter<'a, K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> IntoParallelIterator for &'a mut SecondaryMap<K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, &'a mut V);
+    type Iter = ParIterMut<'a, K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.par_iter_mut()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<K, V> IntoParallelIterator for SecondaryMap<K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = (K, V);
+    type Iter = IntoParIter<K, V>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        IntoParIter {
+            slots: self.slots.into_par_iter().enumerate(),
+            _k: PhantomData,
+        }
+    }
+}
+
+/// A parallel iterator over the keys in a [`SecondaryMap`].
+///
+/// This iterator is created by [`SecondaryMap::par_keys`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParKeys<'a, K: 'a + Key, V: 'a> {
+    inner: ParIter<'a, K, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParKeys<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParKeys {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParKeys<'a, K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = K;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(key, _)| key).drive_unindexed(consumer)
+    }
+}
+
+/// A parallel iterator over the values in a [`SecondaryMap`].
+///
+/// This iterator is created by [`SecondaryMap::par_values`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParValues<'a, K: 'a + Key, V: 'a> {
+    inner: ParIter<'a, K, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K: 'a + Key, V: 'a> Clone for ParValues<'a, K, V> {
+    fn clone(&self) -> Self {
+        ParValues {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParValues<'a, K, V>
+where
+    K: Key + Send,
+    V: Sync,
+{
+    type Item = &'a V;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(_, value)| value).drive_unindexed(consumer)
+    }
+}
+
+/// A parallel mutable iterator over the values in a [`SecondaryMap`].
+///
+/// This iterator is created by [`SecondaryMap::par_values_mut`].
+#[cfg(feature = "rayon")]
+#[derive(Debug)]
+pub struct ParValuesMut<'a, K: 'a + Key, V: 'a> {
+    inner: ParIterMut<'a, K, V>,
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V> ParallelIterator for ParValuesMut<'a, K, V>
+where
+    K: Key + Send,
+    V: Send,
+{
+    type Item = &'a mut V;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        self.inner.map(|(_, value)| value).drive_unindexed(consumer)
+    }
+}
 
 // Serialization with serde.
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Support parallel iteration via a new `rayon` feature. Fixes #98.

AI Disclosure: I prototyped this change with codex. When preparing this PR, I rewrote the change by hand to better match the existing codebase and improve on a few things. I had codex review the final change.

Implementation notes:
* The `dep:` syntax in Cargo.toml requires Rust 1.60. Alternatives seemed ugly, so I bumped the MSRV slightly.
* Cargo.lock was updated via `cargo +nightly update -Z direct-minimal-versions`
* Supported methods: `par_iter`, `par_iter_mut`, `into_par_iter`, `par_keys`, `par_values`, `par_values_mut`
* I skipped supporting `HopSlotMap` since it is deprecated. I skipped `SparseSecondaryMap` for now since it has more complicated internals and I don't personally have a use-case for it.
* I implemented `ParallelIterator` for the `SlotMap` and `SecondaryMap` iterators. For `DenseSlotMap` we can also implement `IndexedParallelIterator` as the iteration maps 1:1 with the underlying data.
* I tried to match the structure of the sequential iterators where possible. In some cases, a slightly different structure allowed for relaxed trait bounds on the parallel iterators and so in those cases there is some deviation.

Let me know if there is anything you'd like me to change.

Thanks you!