### PR TITLE
Make feature-gated items visible in docs.rs documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ quickcheck = "1.0"
 
 [build-dependencies]
 version_check = "0.9"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc"]


### PR DESCRIPTION
Currently, the implementations of `Serialize` and `Deserialize` are invisible on Docs.rs, because they are gated by `serde` feature, and Docs.rs needs a given feature to be enabled to display items behind it in documentation.

So, let's enable all features for Docs.rs.

To enable `feature(doc_cfg)`, which is required for docs to display behind which features each item is, let's also pass `--cfg doc`.